### PR TITLE
Fix for https://github.com/couchbase/couchbase-lite-android/issues/4

### DIFF
--- a/Couchbase-Lite-Android-Ektorp/.classpath
+++ b/Couchbase-Lite-Android-Ektorp/.classpath
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="lib" path="libs/org.ektorp-1.2.2.jar" sourcepath="libs-src/org.ektorp-1.2.2-sources.jar"/>
 	<classpathentry kind="lib" path="../Couchbase-Lite-Android/libs/jackson-core-asl-1.9.2.jar"/>
 	<classpathentry kind="lib" path="../Couchbase-Lite-Android/libs/jackson-mapper-asl-1.9.2.jar"/>
 	<classpathentry kind="lib" path="libs/org.ektorp.android-1.2.2.jar" sourcepath="libs-src/org.ektorp.android-1.2.2-sources.jar"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/Couchbase-Lite-Android-JavaScript/.classpath
+++ b/Couchbase-Lite-Android-JavaScript/.classpath
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="lib" path="libs/js.jar"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/Couchbase-Lite-Android-Listener/.classpath
+++ b/Couchbase-Lite-Android-Listener/.classpath
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="lib" path="libs/servlet-api-2.4.jar"/>
 	<classpathentry kind="lib" path="libs/webserver.jar"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/Couchbase-Lite-Android-TestApp/.classpath
+++ b/Couchbase-Lite-Android-TestApp/.classpath
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="lib" path="../Couchbase-Lite-Android/libs/jackson-core-asl-1.9.2.jar"/>
 	<classpathentry kind="lib" path="../Couchbase-Lite-Android/libs/jackson-mapper-asl-1.9.2.jar"/>
 	<classpathentry kind="lib" path="../Couchbase-Lite-Android-Listener/libs/webserver.jar"/>
@@ -11,5 +11,6 @@
 	<classpathentry combineaccessrules="false" kind="src" path="/Couchbase-Lite-Android"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/Couchbase-Lite-Android-Ektorp"/>
 	<classpathentry combineaccessrules="false" kind="src" path="/Couchbase-Lite-Android-Listener"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>

--- a/Couchbase-Lite-Android/.classpath
+++ b/Couchbase-Lite-Android/.classpath
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="con" path="com.android.ide.eclipse.adt.ANDROID_FRAMEWORK"/>
-	<classpathentry kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
+	<classpathentry exported="true" kind="con" path="com.android.ide.eclipse.adt.LIBRARIES"/>
 	<classpathentry kind="lib" path="libs/jackson-core-asl-1.9.2.jar"/>
 	<classpathentry kind="lib" path="libs/jackson-mapper-asl-1.9.2.jar"/>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="src" path="gen"/>
+	<classpathentry kind="con" path="com.android.ide.eclipse.adt.DEPENDENCIES"/>
 	<classpathentry kind="output" path="bin/classes"/>
 </classpath>


### PR DESCRIPTION
Updates .classpath files. Fix for issue: https://github.com/couchbase/couchbase-lite-android/issues/4 "Upgrade to Android SDK R22 causes NoClassDefFound error".
