### PR TITLE
exposing getters and setters on replicator classes

### DIFF
--- a/Couchbase-Lite-Android/src/com/couchbase/cblite/replicator/CBLPusher.java
+++ b/Couchbase-Lite-Android/src/com/couchbase/cblite/replicator/CBLPusher.java
@@ -37,6 +37,10 @@ public class CBLPusher extends CBLReplicator implements Observer {
         createTarget = false;
         observing = false;
     }
+    
+    public boolean isCreateTarget() {
+        return createTarget;
+    }
 
     public void setCreateTarget(boolean createTarget) {
         this.createTarget = createTarget;

--- a/Couchbase-Lite-Android/src/com/couchbase/cblite/replicator/CBLReplicator.java
+++ b/Couchbase-Lite-Android/src/com/couchbase/cblite/replicator/CBLReplicator.java
@@ -89,12 +89,30 @@ public abstract class CBLReplicator extends Observable {
 		};
     }
 
+    public String getFilterName() {
+        return filterName;
+    }
+    
     public void setFilterName(String filterName) {
         this.filterName = filterName;
+    }
+    
+    public Map<String,Object> getFilterParams() {
+        return filterParams;
     }
 
     public void setFilterParams(Map<String, Object> filterParams) {
         this.filterParams = filterParams;
+    }
+    
+    public boolean isContinuous() {
+        return continuous;
+    }
+    
+    public void setContinuous(boolean continuous) {
+        if (!isRunning()) {
+            this.continuous = continuous;
+        }
     }
 
     public boolean isRunning() {


### PR DESCRIPTION
This change is mainly for parity with the iOS version.  New methods are:
- CBLPusher.isCreateTarget()
- CBLReplicator.getFilterName()
- CBLReplicator.getFilterParams()
- CBLReplicator.isContinuous()
- CBLReplicator.setContinuous()

Calling setContinuous when replication is running has no effect.  Since these are all simple getters and setters, I didn't add unit tests for them.
