### PR TITLE
Broken link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ _Note_: the above workarounds are only needed for Android Studio, and even witho
 
 ## Running tests
 
-See the [[Running the Test Suite]] wiki page.
+See the [Running the Test Suite](https://github.com/couchbase/couchbase-lite-android/wiki/Running-the-test-suite) wiki page.
 
 ## Building and deploying maven artifacts.
 


### PR DESCRIPTION
Fixes the link to "Running the Test Suite" in the readme - hopefully saves someone a couple clicks down the line.
