### PR TITLE
Removed unused appcompat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,6 @@ def buildAndroidWithArtifacts = System.getProperty("buildAndroidWithArtifacts")
 
 dependencies {
 
-    compile 'com.android.support:appcompat-v7:+'
-
     // this library is only needed by test code (95% certain), and therefore
     // instrumentTestCompile is used rather than compile.
     instrumentTestCompile 'commons-io:commons-io:2.0.1'


### PR DESCRIPTION
This library has exactly 5300 java methods that are not being used in the couchbase project and it influences badly in the way that increases the probability of reaching the limit of 64K methods that can be "included" in an apk.
