### PR TITLE
Add test verifying that views do not index design docs

### DIFF
--- a/src/instrumentTest/java/com/couchbase/lite/ViewsTest.java
+++ b/src/instrumentTest/java/com/couchbase/lite/ViewsTest.java
@@ -299,6 +299,19 @@ public class ViewsTest extends LiteTestCase {
         view.deleteIndex();
     }
 
+    public void testViewIndexSkipsDesignDocs() throws CouchbaseLiteException {
+        View view = createView(database);
+
+        Map<String, Object> designDoc = new HashMap<String, Object>();
+        designDoc.put("_id", "_design/test");
+        designDoc.put("key", "value");
+        putDoc(database, designDoc);
+
+        view.updateIndex();
+        List<QueryRow> rows = view.queryWithOptions(null);
+        assertEquals(0, rows.size());
+    }
+
     public void testViewQuery() throws CouchbaseLiteException {
 
         putDocs(database);


### PR DESCRIPTION
Added a new test verifying that views don't index design documents. This test reproduces a bug (couchbase/couchbase-lite-java-core#173) where updateIndex() will crash if the last document to index is a design doc. I could have tested the crash condition directly, but I thought this test would be more meaningful/useful.
