### PR TITLE
Fix for #239

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -101,11 +101,17 @@ task uploadArchivesWrapper(dependsOn: createMavenDirectory) << {
     uploadArchives.execute()
 }
 
+def mavenPath() {
+    System.getenv("MAVEN_BUILD_LOCAL") == "true" ?
+            'file://' + new File(System.getProperty('user.home'), '.m2/repository').absolutePath :
+            System.getenv("MAVEN_UPLOAD_REPO_URL")
+}
+
 // this will upload, but will not first create a directory (which is needed on some servers)
 uploadArchives {
     repositories {
         mavenDeployer {
-            repository(url: System.getenv("MAVEN_UPLOAD_REPO_URL")) {
+            repository(url: mavenPath()) {
                 authentication(userName: System.getenv("MAVEN_UPLOAD_USERNAME"), password: System.getenv("MAVEN_UPLOAD_PASSWORD"))
             }
             pom.version = System.getenv("MAVEN_UPLOAD_VERSION")


### PR DESCRIPTION
Unfortunately I can't really test this because my build environment is very (very) different than Couchbase's. Once couchbase switches to using gradle properties then everything will be fine. But that's a different bug.

The only interesting change is that I introduced a new variable, MAVEN_BUILD_LOCAL. If set to true then the system will upload to mavenLocal(). Otherwise it will upload to the Maven depot specified by MAVEN_UPLOAD_REPO_URL.
