### PR TITLE
Please close the stream

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/LiteTestCase.java
+++ b/src/androidTest/java/com/couchbase/lite/LiteTestCase.java
@@ -390,7 +390,9 @@ public abstract class LiteTestCase extends LiteTestCaseBase {
         assertEquals(rev3.getAttachmentNames(), attNames);
 
         assertEquals("text/plain; charset=utf-8", attach.getContentType());
-        assertEquals(IOUtils.toString(attach.getContent(), "UTF-8"), content);
+        InputStream attachInputStream = attach.getContent();
+        assertEquals(IOUtils.toString(attachInputStream, "UTF-8"), content);
+        attachInputStream.close();
         assertEquals(content.getBytes().length, attach.getLength());
 
         return doc;


### PR DESCRIPTION
The stream doesn't get closed so at least in Java on Windows this means all subsequent tests fail because they can't clean up the directory since this stream is still open and holding a handle on the file.
