### PR TITLE
Please close the input stream

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ApiTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ApiTest.java
@@ -592,6 +592,7 @@ public class ApiTest extends LiteTestCase {
         Attachment fetched = doc.getCurrentRevision().getAttachment(attachmentName);
         InputStream is = fetched.getContent();
         byte[] attachmentBytes = TextUtils.read(is);
+        is.close();
         assertEquals(content, new String(attachmentBytes));
         assertNotNull(fetched);
 


### PR DESCRIPTION
This input stream doesn't get closed so in Java in Windows it causes all subsequent tests involving cblite to fail because they can't clean up the test directory.
