### PR TITLE
Add couchbase-lite-java-listener to settings.gradle.example

### DIFF
--- a/settings.gradle.example
+++ b/settings.gradle.example
@@ -1,1 +1,1 @@
-include ':couchbase-lite-android', ':libraries:couchbase-lite-java-core'
+include ':couchbase-lite-android', ':libraries:couchbase-lite-java-core', ':libraries:couchbase-lite-java-listener'


### PR DESCRIPTION
This makes it easier to set up couchbase-lite-android for dev, since the listener project is now required for the tests to compile.
