### PR TITLE
Add tests for CBL's cached properties getting changed by clients

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/DocumentTest.java
+++ b/src/androidTest/java/com/couchbase/lite/DocumentTest.java
@@ -201,4 +201,18 @@ public class DocumentTest extends LiteTestCase {
         assertTrue(thirdLevelImmutable);
     }
 
+    public void testProvidedMapChangesAreSafe() throws Exception {
+        Map<String, Object> originalProps = new HashMap<String, Object>();
+        Document doc = createDocumentWithProperties(database, originalProps);
+
+        Map<String, Object> nestedProps = new HashMap<String, Object>();
+        nestedProps.put("version", "original");
+        UnsavedRevision rev = doc.createRevision();
+        rev.getProperties().put("nested", nestedProps);
+        rev.save();
+
+        nestedProps.put("version", "changed");
+        assertEquals("original", ((Map) doc.getProperty("nested")).get("version"));
+    }
+
 }


### PR DESCRIPTION
One test for couchbase/couchbase-lite-java-core#228, and another that demonstrates that clients can give a map to CBL, then change that map, and it clobbers what's in CBL's cache.
