### PR TITLE
Loosed the assertTrue a little

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/support/BatcherTest.java
+++ b/src/androidTest/java/com/couchbase/lite/support/BatcherTest.java
@@ -57,7 +57,7 @@ public class BatcherTest extends LiteTestCase {
         assertTrue(didNotTimeOut);
 
         long delta = timeProcessed.get() - timeQueued;
-        assertTrue(delta > 0);
+        assertTrue(delta >= 0);
 
         // we want the delta between the time it was queued until the
         // time it was processed to be as small as possible.  since


### PR DESCRIPTION
I actually had a test run fail because the delta equaled zero. Let's not penalize folks for fast machines. :) Given the purpose of the test I believe this change is o.k. Thoughts?
