### PR TITLE
Getting rid of wrapper

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,10 +79,6 @@ task generateJavadocs(type: Javadoc) {
     exclude "org/apache/http/**", "com/couchbase/touchdb/**"
 }
 
-task wrapper(type: Wrapper) {
-	gradleVersion = '1.10'
-}
-
 task createMavenDirectory(type: Exec) {
 
     ext {


### PR DESCRIPTION
We don't really need wrapper anymore (since gradlew is already set up) and anyway the version was wrong. I believe we are now at 1.11. Probably easiest to just get rid of it all together.
