### PR TITLE
Proof for Docs not inserted during pull with validation

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -747,6 +747,40 @@ public class ReplicationTest extends LiteTestCase {
     }
 
     /**
+     * Verify that Validation based Rejects revert the entire batch that the document is in
+     * even if one of the documents fail the validation.
+     *
+     * @throws Exception
+     */
+    public void testVerifyPullerInsertsDocsWithValidation() throws Exception {
+        // create mockwebserver and custom dispatcher
+        MockDispatcher dispatcher = new MockDispatcher();
+        MockWebServer server = MockHelper.getPreloadedPullTargetServer(dispatcher, 2, 2);
+        server.play();
+
+        // Setup validation to reject document with id: doc1
+        database.setValidation("validateOnlyDoc1", new Validator() {
+            @Override
+            public void validate(Revision newRevision, ValidationContext context) {
+                if ("doc1".equals(newRevision.getDocument().getId())) {
+                    context.reject();
+                }
+            }
+        });
+
+        // run pull replication
+        Replication pullReplication = doPullReplication(server.getUrl("/db"));
+
+        assertNotNull(database);
+        // doc1 should not be in the store because of validation
+        assertNull(database.getExistingDocument("doc1"));
+
+        // doc0 should be in the store, but it wont be because of the bug.
+        assertNotNull(database.getExistingDocument("doc0"));
+
+    }
+
+    /**
      * Pull replication test:
      *
      * - Single one-shot pull replication


### PR DESCRIPTION
When pulling documents from sync gateway with validation block, the entire batch
of documents get reverted even if one of the documents in the batch fails validation.
This is due to the way nested transactions are handled and cause incorrect behaviour.

Testcase for: https://github.com/couchbase/couchbase-lite-java-core/issues/242
