### PR TITLE
Continuous replications stay in "limbo" after failing to get checkpoint on start

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/replicator/MockHelper.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/MockHelper.java
@@ -57,6 +57,9 @@ public class MockHelper {
 
     }
 
+    public static void set503ServiceUnavailable(MockResponse mockResponse) {
+        mockResponse.setStatus("HTTP/1.1 503 Service Unavailable").setHeader("Content-Type", "application/json");
+    }
 
     public static void set200OKJson(MockResponse mockResponse) {
         mockResponse.setStatus("HTTP/1.1 200 OK").setHeader("Content-Type", "application/json");


### PR DESCRIPTION
When a continuous replication is started, if it fails to get the _local checkpoint 3 times with an error other than a 404, the replicator never starts, but its state doesn't change do STOPPED or OFFLINE, it just stays IDLE forever and never tries to make new requests 

In the Replication fetchRemoteCheckpointDoc() if the error is different from 404 it just sets the replication error and the beginReplicating() method is never called(https://github.com/couchbase/couchbase-lite-java-core/blob/master/src/main/java/com/couchbase/lite/replicator/Replication.java#L1224-1226). 

A backoff mechanism should be implemented to correct this behaviour and guarantee the replicator doesn't stay IDLE forever without making new requests.