### PR TITLE
Please upgrade mockwebserver to at least 1.3.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,7 +61,7 @@ dependencies {
             project(':libraries:couchbase-lite-java-core') :
             'com.couchbase.lite:couchbase-lite-java-core:' + System.getenv("MAVEN_UPLOAD_VERSION")
 
-    androidTestCompile 'com.squareup.okhttp:mockwebserver:1.2.1'
+    androidTestCompile 'com.squareup.okhttp:mockwebserver:1.3.0'
 
 }
 


### PR DESCRIPTION
When I try to run the couchbase-lite-android tests using Gradle 1.12 on Intellij Ultimate 14 EAP I run into https://github.com/square/okhttp/issues/357. This bug was actually fixed in mockwebserver 1.3.0. In fact mockwebserver is now at 2.0, I'm not sure why we aren't using the latest but I tried at 1.3.0 and it at least got me past that bug (I'm now grappling with a different bug in Test16_ParallelPushReplication but that's another story).
