### PR TITLE
Fix https://github.com/couchbase/couchbase-lite-java-core/issues/279

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -1076,10 +1076,13 @@ public class ReplicationTest extends LiteTestCase {
         Attachment attachment = doc1.getCurrentRevision().getAttachment(attachmentName);
         assertTrue(attachment.getLength() > 0);
         assertTrue(attachment.getGZipped());
-        byte[] receivedBytes = TextUtils.read(attachment.getContent());
+        InputStream is = attachment.getContent();
+        byte[] receivedBytes = TextUtils.read(is);
+        is.close();
 
         InputStream attachmentStream = getAsset(attachmentName);
         byte[] actualBytes = TextUtils.read(attachmentStream);
+        attachmentStream.close();
         Assert.assertEquals(actualBytes.length, receivedBytes.length);
         Assert.assertEquals(actualBytes, receivedBytes);
 
@@ -1666,7 +1669,9 @@ public class ReplicationTest extends LiteTestCase {
         int attachLength = testAttachBytes.length;
         assertEquals(attachLength, attachment.getLength());
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        baos.write(attachment.getContent());
+        InputStream is = attachment.getContent();
+        baos.write(is);
+        is.close();
         byte[] actualAttachBytes = baos.toByteArray();
         assertEquals(testAttachBytes.length, actualAttachBytes.length);
         for (int i=0; i<actualAttachBytes.length; i++) {


### PR DESCRIPTION
https://github.com/couchbase/couchbase-lite-java-core/issues/279 is proximally caused by a failure to close the content stream in attachmentAsserts. So this fixes that. But of course https://github.com/couchbase/couchbase-lite-java-core/issues/210 is the real issue!! :)

I also threw in a fix for the same issue in failingTestPullerGzipped just in case at some point it gets re-activated again.
