### PR TITLE
issue 81: new package names for internal copy of HTTPCore

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/mockserver/MockDocumentGet.java
+++ b/src/androidTest/java/com/couchbase/lite/mockserver/MockDocumentGet.java
@@ -7,9 +7,9 @@ import com.couchbase.lite.support.Base64;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.http.entity.mime.MultipartEntity;
-import org.apache.http.entity.mime.content.InputStreamBody;
-import org.apache.http.entity.mime.content.StringBody;
+import com.couchbase.org.apache.http.entity.mime.MultipartEntity;
+import com.couchbase.org.apache.http.entity.mime.content.InputStreamBody;
+import com.couchbase.org.apache.http.entity.mime.content.StringBody;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -57,7 +57,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.cookie.Cookie;
-import org.apache.http.entity.mime.MultipartEntity;
+import com.couchbase.org.apache.http.entity.mime.MultipartEntity;
 
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
Updated internal HTTPCore package names in the unit test code to conform with the PR that fixes issue #81 as requested in https://github.com/couchbase/couchbase-lite-java-core/pull/314.
