### PR TITLE
use java 1.6 to compile project and create zip file

### DIFF
--- a/release/pom.xml
+++ b/release/pom.xml
@@ -125,6 +125,19 @@
     </dependencies>
     
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>2.3.2</version>
+                    <configuration>
+                        <source>1.6</source>
+                        <target>1.6</target>
+                        <compilerArgument></compilerArgument>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
by default maven uses 1.3 java -> Maven : error: generics are not supported in -source 1.3
