### PR TITLE
Adjust unit test case, failingTestPushRetry(), for #299 of CBL java core

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -861,6 +861,7 @@ public class ReplicationTest extends LiteTestCase {
     public void testFailingTestPushRetry() throws Exception {
 
         RemoteRequestRetry.RETRY_DELAY_MS = 5; // speed up test execution
+        ReplicationInternal.RETRY_DELAY   = 1; // speed up test execution (sec)
 
         // create mockwebserver and custom dispatcher
         MockDispatcher dispatcher = new MockDispatcher();

--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -858,10 +858,10 @@ public class ReplicationTest extends LiteTestCase {
      *
      * @throws Exception
      */
-    public void testFailingTestPushRetry() throws Exception {
+    public void testContinuousPushRetryBehavior() throws Exception {
 
         RemoteRequestRetry.RETRY_DELAY_MS = 5; // speed up test execution
-        ReplicationInternal.RETRY_DELAY   = 1; // speed up test execution (sec)
+        ReplicationInternal.RETRY_DELAY_SECONDS = 1; // speed up test execution (sec)
 
         // create mockwebserver and custom dispatcher
         MockDispatcher dispatcher = new MockDispatcher();
@@ -913,14 +913,8 @@ public class ReplicationTest extends LiteTestCase {
             dispatcher.takeRecordedResponseBlocking(request);
         }
 
-        // TODO: test fails here, because there's nothing to cause it to retry after the
-        // TODO: request does it's retry attempt.  Eg, continuous replicator needs to keep
-        // TODO: sending new requests
-        // but it shouldn't give up there, it should keep retrying, so we should expect to
-        // see at least one more request (probably lots more, but let's just wait for one)
-
         // By 12/16/2014, CBL core java tries RemoteRequestRetry.MAX_RETRIES + 1 see above.
-        // following code should cause hang.
+        // Without fixing #299, following code should cause hang.
 
         // CBL java core should retry till success if it is retry-able.
         // As Unit Test, we only check if replicator try at least two more attempts.

--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -919,7 +919,7 @@ public class ReplicationTest extends LiteTestCase {
         // Without fixing #299, following code should cause hang.
 
         // outer retry loop
-        for(int j = 0; j < RemoteRequestRetry.MAX_RETRIES; j++){
+        for(int j = 0; j < ReplicationInternal.MAX_RETRIES; j++){
             // inner retry loop
             for (int i=0; i < numAttempts; i++) {
                 RecordedRequest request = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_BULK_DOCS);

--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -860,8 +860,10 @@ public class ReplicationTest extends LiteTestCase {
      */
     public void testContinuousPushRetryBehavior() throws Exception {
 
-        RemoteRequestRetry.RETRY_DELAY_MS = 5; // speed up test execution
-        ReplicationInternal.RETRY_DELAY_SECONDS = 1; // speed up test execution (sec)
+        RemoteRequestRetry.RETRY_DELAY_MS = 5;       // speed up test execution (inner loop retry delay)
+
+        ReplicationInternal.RETRY_DELAY_SECONDS = 1; // speed up test execution (outer loop retry delay)
+        ReplicationInternal.MAX_RETRIES = 3;         // spped up test execution (outer loop retry count)
 
         // create mockwebserver and custom dispatcher
         MockDispatcher dispatcher = new MockDispatcher();
@@ -916,10 +918,9 @@ public class ReplicationTest extends LiteTestCase {
         // By 12/16/2014, CBL core java tries RemoteRequestRetry.MAX_RETRIES + 1 see above.
         // Without fixing #299, following code should cause hang.
 
-        // CBL java core should retry till success if it is retry-able.
-        // As Unit Test, we only check if replicator try at least two more attempts.
-        int NUM_RETRY = 2;
-        for(int j = 0; j < NUM_RETRY; j++){
+        // outer retry loop
+        for(int j = 0; j < RemoteRequestRetry.MAX_RETRIES; j++){
+            // inner retry loop
             for (int i=0; i < numAttempts; i++) {
                 RecordedRequest request = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_BULK_DOCS);
                 assertNotNull(request);


### PR DESCRIPTION
As prefix "test" before failingTestPushRetry() method. This test case blocks test without updated CBL java core