### PR TITLE
Feature/issue 352 get session and checkpoint when retrying replication

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/mockserver/MockFacebookAuthPost.java
+++ b/src/androidTest/java/com/couchbase/lite/mockserver/MockFacebookAuthPost.java
@@ -15,4 +15,24 @@ public class MockFacebookAuthPost {
         return mockResponse;
     }
 
+    public MockResponse generateMockResponseForSuccess(String email) {
+        /**
+         * Facebook actual response
+         *
+        HTTP/1.1 200 OK
+        Date: Mon, 22 Dec 2014 22:16:31 GMT
+        Content-Type: application/json
+        Content-Length: 568
+        Connection: keep-alive
+        Server: Couchbase Sync Gateway/1.00
+        Set-Cookie: SyncGatewaySession=015f9770ebe9968ae04306f591d38e12c1391886; Path=/todolite/; Expires=Tue, 23 Dec 2014 22:16:31 UTC
+
+        {"authentication_handlers":["default","cookie"],"ok":true,"userCtx":{"channels":{"list-00F9B6FC-7B2C-47A8-9E4C-0855E1468A96":376,"list-07FB5332-7D6E-4B43-9C4B-A3C48F6548A4":57408,"list-0919487F-1D3D-41CE-88A0-C3F08BEFFF0D":381,"list-4290A9F4-0BCD-4C49-BEAF-4177B7585CD7":57507,"list-66ece56f-2422-4d4a-8858-583ddb665ec5":58528,"list-67C0AD63-6946-42AC-BF2A-3CAE7DCDD1C4":57761,"list-7E0A551D-13CC-4008-8749-125CC11E2F98":59284,"list-DF3A5540-8A99-4222-9C77-74D83DE2B8A6":428,"list-E5C26632-4E5A-46F0-9C97-C09698BF20D5":57801,"profiles":375},"name":"myfacebook@gmail.com"}}
+         */
+        MockResponse mockResponse = new MockResponse();
+        String jsonBody = "{\"name\":\""+email+"\"}";
+        mockResponse.setBody(jsonBody);
+        mockResponse.setStatus("HTTP/1.1 200 OK").setHeader("Content-Type", "application/json");
+        return mockResponse;
+    }
 }

--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -3696,4 +3696,167 @@ public class ReplicationTest extends LiteTestCase {
 
         server.shutdown();
     }
+
+    /**
+     * https://github.com/couchbase/couchbase-lite-java-core/issues/352
+     *
+     * When retrying a replication, make sure to get session & checkpoint.
+     *
+     */
+    public void testCheckSessionAndCheckpointWhenRetryingReplication() throws Exception{
+
+        RemoteRequestRetry.RETRY_DELAY_MS = 5;       // speed up test execution (inner loop retry delay)
+
+        ReplicationInternal.RETRY_DELAY_SECONDS = 1; // speed up test execution (outer loop retry delay)
+        ReplicationInternal.MAX_RETRIES = 3;         // spped up test execution (outer loop retry count)
+
+
+        String fakeEmail = "myfacebook@gmail.com";
+
+        // create mockwebserver and custom dispatcher
+        MockDispatcher dispatcher = new MockDispatcher();
+        MockWebServer server = MockHelper.getMockWebServer(dispatcher);
+        dispatcher.setServerType(MockDispatcher.ServerType.SYNC_GW);
+
+        // set up request
+        {
+            // response for /db/_session
+            MockSessionGet mockSessionGet = new MockSessionGet();
+            dispatcher.enqueueResponse(MockHelper.PATH_REGEX_SESSION, mockSessionGet.generateMockResponse());
+
+            // response for /db/_facebook
+            MockFacebookAuthPost mockFacebookAuthPost = new MockFacebookAuthPost();
+            dispatcher.enqueueResponse(MockHelper.PATH_REGEX_FACEBOOK_AUTH, mockFacebookAuthPost.generateMockResponseForSuccess(fakeEmail));
+
+            // response for /db/_local/.*
+            MockCheckpointPut mockCheckpointPut = new MockCheckpointPut();
+            mockCheckpointPut.setSticky(true);
+            mockCheckpointPut.setDelayMs(500);
+            dispatcher.enqueueResponse(MockHelper.PATH_REGEX_CHECKPOINT, mockCheckpointPut);
+
+            // response for /db/_revs_diff
+            MockRevsDiff mockRevsDiff = new MockRevsDiff();
+            mockRevsDiff.setSticky(true);
+            dispatcher.enqueueResponse(MockHelper.PATH_REGEX_REVS_DIFF, mockRevsDiff);
+
+            // response for /db/_bulk_docs  -- 503 errors
+            MockResponse mockResponse = new MockResponse().setResponseCode(503);
+            WrappedSmartMockResponse mockBulkDocs = new WrappedSmartMockResponse(mockResponse, false);
+            mockBulkDocs.setSticky(true);
+            dispatcher.enqueueResponse(MockHelper.PATH_REGEX_BULK_DOCS, mockBulkDocs);
+        }
+        server.play();
+
+        // register bogus fb token
+        Authenticator facebookAuthenticator = AuthenticatorFactory.createFacebookAuthenticator("fake_access_token");
+
+        // create replication
+        Replication replication = database.createPushReplication(server.getUrl("/db"));
+        replication.setAuthenticator(facebookAuthenticator);
+        replication.setContinuous(true);
+        CountDownLatch replicationIdle = new CountDownLatch(1);
+        ReplicationIdleObserver idleObserver = new ReplicationIdleObserver(replicationIdle);
+        replication.addChangeListener(idleObserver);
+        replication.start();
+
+        // wait until idle
+        boolean success = replicationIdle.await(30, TimeUnit.SECONDS);
+        assertTrue(success);
+        replication.removeChangeListener(idleObserver);
+
+        // create a doc in local db
+        Document doc1 = createDocumentForPushReplication("doc1", null, null);
+
+        // initial request
+        {
+            // check /db/_session
+            RecordedRequest sessionRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_SESSION);
+            assertNotNull(sessionRequest);
+            dispatcher.takeRecordedResponseBlocking(sessionRequest);
+
+            // check /db/_facebook
+            RecordedRequest facebookSessionRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_FACEBOOK_AUTH);
+            assertNotNull(facebookSessionRequest);
+            dispatcher.takeRecordedResponseBlocking(facebookSessionRequest);
+
+            // check /db/_local/.*
+            RecordedRequest checkPointRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_CHECKPOINT);
+            assertNotNull(checkPointRequest);
+            dispatcher.takeRecordedResponseBlocking(checkPointRequest);
+
+            // check /db/_revs_diff
+            RecordedRequest revsDiffRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_REVS_DIFF);
+            assertNotNull(revsDiffRequest);
+            dispatcher.takeRecordedResponseBlocking(revsDiffRequest);
+
+            // we should expect to at least see numAttempts attempts at doing POST to _bulk_docs
+            // 1st attempt
+            // numAttempts are number of times retry in 1 attempt.
+            int numAttempts = RemoteRequestRetry.MAX_RETRIES + 1; // total number of attempts = 4 (1 initial + MAX_RETRIES)
+            for (int i = 0; i < numAttempts; i++) {
+                RecordedRequest request = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_BULK_DOCS);
+                assertNotNull(request);
+                dispatcher.takeRecordedResponseBlocking(request);
+            }
+        }
+
+        // To test following, requires to fix #299 (improve retry behavior)
+
+        // Retry requests
+        // outer retry loop
+        for(int j = 0; j < ReplicationInternal.MAX_RETRIES; j++){
+
+            // MockSessionGet does not support isSticky
+            MockSessionGet mockSessionGet = new MockSessionGet();
+            dispatcher.enqueueResponse(MockHelper.PATH_REGEX_SESSION, mockSessionGet.generateMockResponse());
+
+            // MockFacebookAuthPost does not support isSticky
+            MockFacebookAuthPost mockFacebookAuthPost = new MockFacebookAuthPost();
+            dispatcher.enqueueResponse(MockHelper.PATH_REGEX_FACEBOOK_AUTH, mockFacebookAuthPost.generateMockResponseForSuccess(fakeEmail));
+
+            // *** Retry must include session & check point ***
+
+            // check /db/_session
+            RecordedRequest sessionRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_SESSION);
+            assertNotNull(sessionRequest);
+            dispatcher.takeRecordedResponseBlocking(sessionRequest);
+
+            // check /db/_facebook
+            RecordedRequest facebookSessionRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_FACEBOOK_AUTH);
+            assertNotNull(facebookSessionRequest);
+            dispatcher.takeRecordedResponseBlocking(facebookSessionRequest);
+
+            // check /db/_local/.*
+            RecordedRequest checkPointRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_CHECKPOINT);
+            assertNotNull(checkPointRequest);
+            dispatcher.takeRecordedResponseBlocking(checkPointRequest);
+
+            // check /db/_revs_diff
+            RecordedRequest revsDiffRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_REVS_DIFF);
+            assertNotNull(revsDiffRequest);
+            dispatcher.takeRecordedResponseBlocking(revsDiffRequest);
+
+            // we should expect to at least see numAttempts attempts at doing POST to _bulk_docs
+            // 1st attempt
+            // numAttempts are number of times retry in 1 attempt.
+            int numAttempts = RemoteRequestRetry.MAX_RETRIES + 1; // total number of attempts = 4 (1 initial + MAX_RETRIES)
+            for (int i = 0; i < numAttempts; i++) {
+                RecordedRequest request = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_BULK_DOCS);
+                assertNotNull(request);
+                dispatcher.takeRecordedResponseBlocking(request);
+            }
+        }
+
+        stopReplication(replication);
+
+        //server.shutdown();
+    }
+    /**
+     * https://github.com/couchbase/couchbase-lite-java-core/issues/352
+     *
+     * Makes the replicator stop, even if it’s continuous, when it receives a permanent-type error
+     */
+    public void testStopReplicatorWhenRetryingReplicationWithPermanentError() throws Exception{
+
+    }
 }


### PR DESCRIPTION
Add test cases for CBL Java Core #352 


- testCheckSessionAndCheckpointWhenRetryingReplication()
  - When retrying a replication, make sure to get session & checkpoint.
  - This test case must pass with fix of CBL Java Core #299. #299 fix also address this scenario.

- testStopReplicatorWhenRetryingReplicationWithPermanentError()
  - Makes the replicator stop, even if it’s continuous, when it receives a permanent-type error
  - This test case must pass with fix of CBL Java Core #352 on top of #299 fix.

Note: One of test cases depends on fix of CBL Java Core #299. Another one requires CBL Java Core fix of #299 and #352. Otherwise, new test cases causes hang.
