### PR TITLE
Feature/issue 328 slow push

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/replicator/Replication2Test.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/Replication2Test.java
@@ -1,0 +1,124 @@
+package com.couchbase.lite.replicator;
+
+import com.couchbase.lite.Document;
+import com.couchbase.lite.LiteTestCase;
+import com.couchbase.lite.mockserver.MockBulkDocs;
+import com.couchbase.lite.mockserver.MockCheckpointPut;
+import com.couchbase.lite.mockserver.MockDispatcher;
+import com.couchbase.lite.mockserver.MockHelper;
+import com.couchbase.lite.mockserver.MockRevsDiff;
+import com.couchbase.lite.util.Log;
+import com.squareup.okhttp.mockwebserver.MockWebServer;
+import com.squareup.okhttp.mockwebserver.RecordedRequest;
+
+import junit.framework.Assert;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by hideki on 1/26/15.
+ */
+public class Replication2Test  extends LiteTestCase {
+
+    /**
+     * https://github.com/couchbase/couchbase-lite-java-core/issues/328
+     *
+     * Without bug fix, we observe extra PUT /{db}/_local/xxx for each _bulk_docs request
+     *
+     * 1. Create 200 docs
+     * 2. Start push replicator
+     * 3. GET  /{db}/_local/xxx
+     * 4. PUSH /{db}/_revs_diff x 2
+     * 5. PUSH /{db}/_bulk_docs x 2
+     * 6. PUT  /{db}/_local/xxx
+     */
+    public void testExcessiveCheckpointingDuringPushReplication() throws Exception {
+
+        List<Document> docs = new ArrayList<Document>();
+
+        // 1. Add 200 local documents
+        for(int i = 0; i < 200; i++) {
+            Map<String, Object> properties = new HashMap<String, Object>();
+            properties.put("testExcessiveCheckpointingDuringPushReplication", String.valueOf(i));
+            Document doc = createDocumentWithProperties(database, properties);
+            docs.add(doc);
+        }
+
+        // create mock server
+        MockDispatcher dispatcher = new MockDispatcher();
+        MockWebServer server = new MockWebServer();
+        server.setDispatcher(dispatcher);
+        server.play();
+
+        // checkpoint GET response -> error
+
+        // _revs_diff response -- everything missing
+        MockRevsDiff mockRevsDiff = new MockRevsDiff();
+        mockRevsDiff.setSticky(true);
+        dispatcher.enqueueResponse(MockHelper.PATH_REGEX_REVS_DIFF, mockRevsDiff);
+
+        // _bulk_docs response -- everything stored
+        MockBulkDocs mockBulkDocs = new MockBulkDocs();
+        mockBulkDocs.setSticky(true);
+        dispatcher.enqueueResponse(MockHelper.PATH_REGEX_BULK_DOCS, mockBulkDocs);
+
+        // checkpoint PUT response (sticky)
+        MockCheckpointPut mockCheckpointPut = new MockCheckpointPut();
+        mockCheckpointPut.setSticky(true);
+        dispatcher.enqueueResponse(MockHelper.PATH_REGEX_CHECKPOINT, mockCheckpointPut);
+
+        // 2. Kick off continuous push replication
+        Replication replicator = database.createPushReplication(server.getUrl("/db"));
+        replicator.setContinuous(true);
+        CountDownLatch replicationIdleSignal = new CountDownLatch(1);
+        ReplicationIdleObserver replicationIdleObserver = new ReplicationIdleObserver(replicationIdleSignal);
+        replicator.addChangeListener(replicationIdleObserver);
+        replicator.start();
+
+        // 3. Wait for document to be pushed
+
+        // wait until replication goes idle
+        boolean successful = replicationIdleSignal.await(60, TimeUnit.SECONDS);
+        assertTrue(successful);
+
+        // wait until mock server gets the checkpoint PUT request
+        boolean foundCheckpointPut = false;
+        String expectedLastSequence = "200";
+        while (!foundCheckpointPut) {
+            RecordedRequest request = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_CHECKPOINT);
+            if (request.getMethod().equals("PUT")) {
+                foundCheckpointPut = true;
+                String body = request.getUtf8Body();
+                Log.e("testExcessiveCheckpointingDuringPushReplication", "body => " + body);
+                Assert.assertTrue(body.indexOf(expectedLastSequence) != -1);
+                // wait until mock server responds to the checkpoint PUT request
+                dispatcher.takeRecordedResponseBlocking(request);
+            }
+        }
+
+        // make some assertions about the outgoing _bulk_docs requests
+        RecordedRequest bulkDocsRequest1 = dispatcher.takeRequest(MockHelper.PATH_REGEX_BULK_DOCS);
+        assertNotNull(bulkDocsRequest1);
+        assertBulkDocJsonContainsDoc(bulkDocsRequest1, docs.get(0));
+
+        RecordedRequest bulkDocsRequest2 = dispatcher.takeRequest(MockHelper.PATH_REGEX_BULK_DOCS);
+        assertNotNull(bulkDocsRequest2);
+        assertBulkDocJsonContainsDoc(bulkDocsRequest2, docs.get(100));
+
+        // check if Android CBL client sent only one PUT /{db}/_local/xxxx request
+        // previous check already consume this request, so queue size should be 0.
+        BlockingQueue<RecordedRequest> queue = dispatcher.getRequestQueueSnapshot(MockHelper.PATH_REGEX_CHECKPOINT);
+        assertEquals(0, queue.size());
+
+        // cleanup
+        stopReplication(replicator);
+
+        server.shutdown();
+    }
+}

--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -86,6 +86,7 @@ import java.util.concurrent.atomic.AtomicInteger;
  */
 public class ReplicationTest extends LiteTestCase {
 
+
     /**
      * Continuous puller starts offline
      * Wait for a while .. (til what?)
@@ -4216,99 +4217,7 @@ public class ReplicationTest extends LiteTestCase {
 
     }
 
-    /**
-     * https://github.com/couchbase/couchbase-lite-java-core/issues/328
-     *
-     * Without bug fix, we observe extra PUT /{db}/_local/xxx for each _bulk_docs request
-     *
-     * 1. Create 200 docs
-     * 2. Start push replicator
-     * 3. GET  /{db}/_local/xxx
-     * 4. PUSH /{db}/_revs_diff x 2
-     * 5. PUSH /{db}/_bulk_docs x 2
-     * 6. PUT  /{db}/_local/xxx
-     */
-    public void testExcessiveCheckpointingDuringPushReplication() throws Exception {
 
-        List<Document> docs = new ArrayList<Document>();
-
-        // 1. Add 200 local documents
-        for(int i = 0; i < 200; i++) {
-            Map<String, Object> properties = new HashMap<String, Object>();
-            properties.put("testExcessiveCheckpointingDuringPushReplication", String.valueOf(i));
-            Document doc = createDocumentWithProperties(database, properties);
-            docs.add(doc);
-        }
-
-        // create mock server
-        MockDispatcher dispatcher = new MockDispatcher();
-        MockWebServer server = new MockWebServer();
-        server.setDispatcher(dispatcher);
-        server.play();
-
-        // checkpoint GET response -> error
-
-        // _revs_diff response -- everything missing
-        MockRevsDiff mockRevsDiff = new MockRevsDiff();
-        mockRevsDiff.setSticky(true);
-        dispatcher.enqueueResponse(MockHelper.PATH_REGEX_REVS_DIFF, mockRevsDiff);
-
-        // _bulk_docs response -- everything stored
-        MockBulkDocs mockBulkDocs = new MockBulkDocs();
-        mockBulkDocs.setSticky(true);
-        dispatcher.enqueueResponse(MockHelper.PATH_REGEX_BULK_DOCS, mockBulkDocs);
-
-        // checkpoint PUT response (sticky)
-        MockCheckpointPut mockCheckpointPut = new MockCheckpointPut();
-        mockCheckpointPut.setSticky(true);
-        dispatcher.enqueueResponse(MockHelper.PATH_REGEX_CHECKPOINT, mockCheckpointPut);
-
-        // 2. Kick off continuous push replication
-        Replication replicator = database.createPushReplication(server.getUrl("/db"));
-        replicator.setContinuous(true);
-        CountDownLatch replicationIdleSignal = new CountDownLatch(1);
-        ReplicationIdleObserver replicationIdleObserver = new ReplicationIdleObserver(replicationIdleSignal);
-        replicator.addChangeListener(replicationIdleObserver);
-        replicator.start();
-
-        // 3. Wait for document to be pushed
-
-        // wait until replication goes idle
-        boolean successful = replicationIdleSignal.await(30, TimeUnit.SECONDS);
-        assertTrue(successful);
-
-        // wait until mock server gets the checkpoint PUT request
-        boolean foundCheckpointPut = false;
-        String expectedLastSequence = "200";
-        while (!foundCheckpointPut) {
-            RecordedRequest request = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_CHECKPOINT);
-            if (request.getMethod().equals("PUT")) {
-                foundCheckpointPut = true;
-                Assert.assertTrue(request.getUtf8Body().indexOf(expectedLastSequence) != -1);
-                // wait until mock server responds to the checkpoint PUT request
-                dispatcher.takeRecordedResponseBlocking(request);
-            }
-        }
-
-        // make some assertions about the outgoing _bulk_docs requests
-        RecordedRequest bulkDocsRequest1 = dispatcher.takeRequest(MockHelper.PATH_REGEX_BULK_DOCS);
-        assertNotNull(bulkDocsRequest1);
-        assertBulkDocJsonContainsDoc(bulkDocsRequest1, docs.get(0));
-
-        RecordedRequest bulkDocsRequest2 = dispatcher.takeRequest(MockHelper.PATH_REGEX_BULK_DOCS);
-        assertNotNull(bulkDocsRequest2);
-        assertBulkDocJsonContainsDoc(bulkDocsRequest2, docs.get(100));
-
-        // check if Android CBL client sent only one PUT /{db}/_local/xxxx request
-        // previous check already consume this request, so queue size should be 0.
-        BlockingQueue<RecordedRequest> queue = dispatcher.getRequestQueueSnapshot(MockHelper.PATH_REGEX_CHECKPOINT);
-        assertEquals(0, queue.size());
-
-        // cleanup
-        stopReplication(replicator);
-
-        server.shutdown();
-    }
 
     class CustomMultipartReaderDelegate implements MultipartReaderDelegate  {
         public Map<String, String> headers = null;

--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -37,7 +37,6 @@ import com.couchbase.lite.mockserver.MockFacebookAuthPost;
 import com.couchbase.lite.mockserver.MockHelper;
 import com.couchbase.lite.mockserver.MockRevsDiff;
 import com.couchbase.lite.mockserver.MockSessionGet;
-import com.couchbase.lite.mockserver.SmartMockResponse;
 import com.couchbase.lite.mockserver.WrappedSmartMockResponse;
 import com.couchbase.lite.support.HttpClientFactory;
 import com.couchbase.lite.support.MultipartReader;
@@ -2754,23 +2753,22 @@ public class ReplicationTest extends LiteTestCase {
     /**
      * Test goOffline() method in the context of a continuous pusher.
      *
-     * - Kick off continuous push replication
-     * - Add a local document
-     * - Wait for document to be pushed
-     * - Call goOffline()
-     * - Add a 2nd local document
-     * - Call goOnline()
-     * - Wait for 2nd document to be pushed
+     * - 1. Add a local document
+     * - 2. Kick off continuous push replication
+     * - 3. Wait for document to be pushed
+     * - 4. Call goOffline()
+     * - 6. Call goOnline()
+     * - 5. Add a 2nd local document
+     * - 7. Wait for 2nd document to be pushed
      *
      * @throws Exception
      */
     public void testGoOfflinePusher() throws Exception {
-
         int previous = RemoteRequestRetry.RETRY_DELAY_MS;
         RemoteRequestRetry.RETRY_DELAY_MS = 5;
 
         try {
-            // create local docs
+            // 1. Add a local document
             Map<String,Object> properties = new HashMap<String, Object>();
             properties.put("testGoOfflinePusher", "1");
             Document doc1 = createDocumentWithProperties(database, properties);
@@ -2781,7 +2779,7 @@ public class ReplicationTest extends LiteTestCase {
             server.setDispatcher(dispatcher);
             server.play();
 
-            // checkpoint PUT or GET response (sticky)
+            // checkpoint PUT response (sticky)
             MockCheckpointPut mockCheckpointPut = new MockCheckpointPut();
             mockCheckpointPut.setSticky(true);
             dispatcher.enqueueResponse(MockHelper.PATH_REGEX_CHECKPOINT, mockCheckpointPut);
@@ -2796,13 +2794,15 @@ public class ReplicationTest extends LiteTestCase {
             mockBulkDocs.setSticky(true);
             dispatcher.enqueueResponse(MockHelper.PATH_REGEX_BULK_DOCS, mockBulkDocs);
 
-            // create and start push replication
+            // 2. Kick off continuous push replication
             Replication replicator = database.createPushReplication(server.getUrl("/db"));
             replicator.setContinuous(true);
             CountDownLatch replicationIdleSignal = new CountDownLatch(1);
             ReplicationIdleObserver replicationIdleObserver = new ReplicationIdleObserver(replicationIdleSignal);
             replicator.addChangeListener(replicationIdleObserver);
             replicator.start();
+
+            // 3. Wait for document to be pushed
 
             // wait until replication goes idle
             boolean successful = replicationIdleSignal.await(30, TimeUnit.SECONDS);
@@ -2821,49 +2821,16 @@ public class ReplicationTest extends LiteTestCase {
                 }
             }
 
+            // 4. Call goOffline()
             putReplicationOffline(replicator);
 
-            // during this time, any requests to server will fail, because we
-            // are simulating being offline.  (whether or not the pusher should
-            // even be _sending_ requests during this time is a different story)
-            dispatcher.clearQueuedResponse(MockHelper.PATH_REGEX_REVS_DIFF);
-            dispatcher.clearRecordedRequests(MockHelper.PATH_REGEX_REVS_DIFF);
-            dispatcher.enqueueResponse(MockHelper.PATH_REGEX_REVS_DIFF, new SmartMockResponse() {
-                @Override
-                public MockResponse generateMockResponse(RecordedRequest request) {
-                    return new MockResponse().setResponseCode(500);
-                }
+            // 6. Call goOnline()
+            putReplicationOnline(replicator);
 
-                @Override
-                public boolean isSticky() {
-                    return true;
-                }
-
-                @Override
-                public long delayMs() {
-                    return 0;
-                }
-            });
-
-            // add a 2nd doc to local db
+            // 5. Add a 2nd local document
             properties = new HashMap<String, Object>();
             properties.put("testGoOfflinePusher", "2");
             Document doc2 = createDocumentWithProperties(database, properties);
-
-            // currently, even when offline, adding a new doc will cause it to try pushing the
-            // doc.  (this is questionable behavior, need to check against iOS).  It will retry
-            // twice, so lets wait for two requests to /_revs_diff
-            RecordedRequest revsDiffRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_REVS_DIFF);
-            dispatcher.takeRecordedResponseBlocking(revsDiffRequest);
-            revsDiffRequest = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_REVS_DIFF);
-            dispatcher.takeRecordedResponseBlocking(revsDiffRequest);
-
-            putReplicationOnline(replicator);
-
-            // we are going online again, so the mockwebserver should accept _revs_diff responses again
-            dispatcher.clearQueuedResponse(MockHelper.PATH_REGEX_REVS_DIFF);
-            dispatcher.clearRecordedRequests(MockHelper.PATH_REGEX_REVS_DIFF);
-            dispatcher.enqueueResponse(MockHelper.PATH_REGEX_REVS_DIFF, mockRevsDiff);
 
             // wait until mock server gets the 2nd checkpoint PUT request
             foundCheckpointPut = false;
@@ -2888,12 +2855,11 @@ public class ReplicationTest extends LiteTestCase {
 
             // cleanup
             stopReplication(replicator);
-            server.shutdown();
 
+            server.shutdown();
         } finally {
             RemoteRequestRetry.RETRY_DELAY_MS = previous;
         }
-
     }
 
     /**
@@ -4248,6 +4214,100 @@ public class ReplicationTest extends LiteTestCase {
         stopReplication(pullReplication);
         server.shutdown();
 
+    }
+
+    /**
+     * https://github.com/couchbase/couchbase-lite-java-core/issues/328
+     *
+     * Without bug fix, we observe extra PUT /{db}/_local/xxx for each _bulk_docs request
+     *
+     * 1. Create 200 docs
+     * 2. Start push replicator
+     * 3. GET  /{db}/_local/xxx
+     * 4. PUSH /{db}/_revs_diff x 2
+     * 5. PUSH /{db}/_bulk_docs x 2
+     * 6. PUT  /{db}/_local/xxx
+     */
+    public void testExcessiveCheckpointingDuringPushReplication() throws Exception {
+
+        List<Document> docs = new ArrayList<Document>();
+
+        // 1. Add 200 local documents
+        for(int i = 0; i < 200; i++) {
+            Map<String, Object> properties = new HashMap<String, Object>();
+            properties.put("testExcessiveCheckpointingDuringPushReplication", String.valueOf(i));
+            Document doc = createDocumentWithProperties(database, properties);
+            docs.add(doc);
+        }
+
+        // create mock server
+        MockDispatcher dispatcher = new MockDispatcher();
+        MockWebServer server = new MockWebServer();
+        server.setDispatcher(dispatcher);
+        server.play();
+
+        // checkpoint GET response -> error
+
+        // _revs_diff response -- everything missing
+        MockRevsDiff mockRevsDiff = new MockRevsDiff();
+        mockRevsDiff.setSticky(true);
+        dispatcher.enqueueResponse(MockHelper.PATH_REGEX_REVS_DIFF, mockRevsDiff);
+
+        // _bulk_docs response -- everything stored
+        MockBulkDocs mockBulkDocs = new MockBulkDocs();
+        mockBulkDocs.setSticky(true);
+        dispatcher.enqueueResponse(MockHelper.PATH_REGEX_BULK_DOCS, mockBulkDocs);
+
+        // checkpoint PUT response (sticky)
+        MockCheckpointPut mockCheckpointPut = new MockCheckpointPut();
+        mockCheckpointPut.setSticky(true);
+        dispatcher.enqueueResponse(MockHelper.PATH_REGEX_CHECKPOINT, mockCheckpointPut);
+
+        // 2. Kick off continuous push replication
+        Replication replicator = database.createPushReplication(server.getUrl("/db"));
+        replicator.setContinuous(true);
+        CountDownLatch replicationIdleSignal = new CountDownLatch(1);
+        ReplicationIdleObserver replicationIdleObserver = new ReplicationIdleObserver(replicationIdleSignal);
+        replicator.addChangeListener(replicationIdleObserver);
+        replicator.start();
+
+        // 3. Wait for document to be pushed
+
+        // wait until replication goes idle
+        boolean successful = replicationIdleSignal.await(30, TimeUnit.SECONDS);
+        assertTrue(successful);
+
+        // wait until mock server gets the checkpoint PUT request
+        boolean foundCheckpointPut = false;
+        String expectedLastSequence = "200";
+        while (!foundCheckpointPut) {
+            RecordedRequest request = dispatcher.takeRequestBlocking(MockHelper.PATH_REGEX_CHECKPOINT);
+            if (request.getMethod().equals("PUT")) {
+                foundCheckpointPut = true;
+                Assert.assertTrue(request.getUtf8Body().indexOf(expectedLastSequence) != -1);
+                // wait until mock server responds to the checkpoint PUT request
+                dispatcher.takeRecordedResponseBlocking(request);
+            }
+        }
+
+        // make some assertions about the outgoing _bulk_docs requests
+        RecordedRequest bulkDocsRequest1 = dispatcher.takeRequest(MockHelper.PATH_REGEX_BULK_DOCS);
+        assertNotNull(bulkDocsRequest1);
+        assertBulkDocJsonContainsDoc(bulkDocsRequest1, docs.get(0));
+
+        RecordedRequest bulkDocsRequest2 = dispatcher.takeRequest(MockHelper.PATH_REGEX_BULK_DOCS);
+        assertNotNull(bulkDocsRequest2);
+        assertBulkDocJsonContainsDoc(bulkDocsRequest2, docs.get(100));
+
+        // check if Android CBL client sent only one PUT /{db}/_local/xxxx request
+        // previous check already consume this request, so queue size should be 0.
+        BlockingQueue<RecordedRequest> queue = dispatcher.getRequestQueueSnapshot(MockHelper.PATH_REGEX_CHECKPOINT);
+        assertEquals(0, queue.size());
+
+        // cleanup
+        stopReplication(replicator);
+
+        server.shutdown();
     }
 
     class CustomMultipartReaderDelegate implements MultipartReaderDelegate  {


### PR DESCRIPTION
Add and modify unit test cases for CBL java core  328 (https://github.com/couchbase/couchbase-lite-java-core/issues/328)


NOTE: New test case for Java Core 328 is created in separated java file, Replication2Test.java instead of ReplicationTest.java. It seems one or some of previously finished test cases make influence to the test result of testExcessiveCheckpointingDuringPushReplication(). I could not identify which one of other test cases cause problem. Instead of identifying the issue, I created new Test class. Also ReplicationTest.java class becomes more than 4K lines.