### PR TITLE
Fix  #310 - Blob name should be upper case for compatibility purpose.

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/BlobKeyTest.java
+++ b/src/androidTest/java/com/couchbase/lite/BlobKeyTest.java
@@ -1,0 +1,19 @@
+package com.couchbase.lite;
+
+import com.couchbase.lite.util.Log;
+
+/**
+ * Created by hideki on 2/20/15.
+ */
+public class BlobKeyTest extends LiteTestCase{
+    public void testConvertToHex(){
+        String src = "Hello World!";
+        Log.i(Log.TAG, "SRC => " + src);
+        String hex = BlobKey.convertToHex(src.getBytes());
+        Log.i(Log.TAG, "HEX => " + hex);
+        String dest = new String(BlobKey.convertFromHex(hex));
+        Log.i(Log.TAG, "DEST => " + dest);
+        assertEquals(src, dest);
+        assertEquals(hex.toUpperCase(), hex);
+    }
+}


### PR DESCRIPTION
- This is Unit Test case. Actual fix is in couchbase-lie-java-core