### PR TITLE
Removed workaround code of ApiTest.runLiveQuery()

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ApiTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ApiTest.java
@@ -930,11 +930,6 @@ public class ApiTest extends LiteTestCase {
         // stop the livequery since we are done with it
         query.removeChangeListener(changeListener);
         query.stop();
-
-        // Workaround:
-        // Putting a small sleep to ensure that the liveQuery is done its async update operation.
-        // https://github.com/couchbase/couchbase-lite-java-core/issues/296
-        Thread.sleep(500);
     }
 
     public void testAsyncViewQuery() throws Exception {

--- a/src/androidTest/java/com/couchbase/lite/ApiTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ApiTest.java
@@ -848,15 +848,13 @@ public class ApiTest extends LiteTestCase {
         int numTimesCallbackCalled = atomicInteger.get();
         Log.d(Database.TAG, "testLiveQueryStop: numTimesCallbackCalled is: " + numTimesCallbackCalled + ".  Now adding docs");
 
-        for (int i=0; i<10; i++) {
+        for (int i = 0; i < 10; i++) {
             createDocuments(db, 1);
             Log.d(Database.TAG, "testLiveQueryStop: add a document.  atomicInteger.get(): " + atomicInteger.get());
             assertEquals(numTimesCallbackCalled, atomicInteger.get());
             Thread.sleep(200);
         }
         assertEquals(numTimesCallbackCalled, atomicInteger.get());
-
-
     }
 
     public void testLiveQueryRestart() throws Exception {


### PR DESCRIPTION
Original issue: CBL Java Core 296
https://github.com/couchbase/couchbase-lite-java-core/issues/296