### PR TITLE
Fix for Unit Test Failure on Jenkins (CBL Java Core 509 and 510)

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ManagerTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ManagerTest.java
@@ -231,11 +231,19 @@ public class ManagerTest extends LiteTestCase {
         pull.removeChangeListener(pullStoppedObserver);
         push.removeChangeListener(pushStoppedObserver);
 
+        // give 5 sec to clean thread status.
+        try {
+            Thread.sleep(5 * 1000);
+        } catch (Exception e) {
+        }
+
         // all threads for Executors should be terminated.
         Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
         for (Thread t : threadSet) {
-            assertEquals(-1, t.getName().indexOf("CBLManagerWorkExecutor"));
-            assertEquals(-1, t.getName().indexOf("CBLRequestWorker"));
+            if (t.isAlive()) {
+                assertEquals(-1, t.getName().indexOf("CBLManagerWorkExecutor"));
+                assertEquals(-1, t.getName().indexOf("CBLRequestWorker"));
+            }
         }
 
         // shutdown mock server

--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -4819,10 +4819,18 @@ public class ReplicationTest extends LiteTestCase {
         stopReplication(pull);
         stopReplication(push);
 
+        // give 5 sec to clean thread status.
+        try {
+            Thread.sleep(5 * 1000);
+        } catch (Exception e) {
+        }
+
         // all threads which are associated with replicators should be terminated.
         Set<Thread> threadSet = Thread.getAllStackTraces().keySet();
         for (Thread t : threadSet) {
-            assertEquals(-1, t.getName().indexOf("CBLRequestWorker"));
+            if (t.isAlive()) {
+                assertEquals(-1, t.getName().indexOf("CBLRequestWorker"));
+            }
         }
 
         // shutdown mock server


### PR DESCRIPTION
- Give 5 second to system to cleanup thread status (as Unit Test failure is only observed with Android default emulator with ARM)
- Also check if Thread is alive.