### PR TITLE
Fixed CBL Java Core 521 - Jenkins: UnitTest failure with BatcherTest.tes...

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/support/BatcherTest.java
+++ b/src/androidTest/java/com/couchbase/lite/support/BatcherTest.java
@@ -3,6 +3,7 @@ package com.couchbase.lite.support;
 import com.couchbase.lite.Database;
 import com.couchbase.lite.LiteTestCase;
 import com.couchbase.lite.util.Log;
+import com.couchbase.lite.util.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +56,8 @@ public class BatcherTest extends LiteTestCase {
         boolean didNotTimeOut = doneSignal.await(35, TimeUnit.SECONDS);
         assertTrue(didNotTimeOut);
 
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     /**
@@ -63,7 +66,6 @@ public class BatcherTest extends LiteTestCase {
      * Also make sure that they appear in the correct order within a batch.
      */
     public void testBatcherBatchSize5() throws Exception {
-
 
         ScheduledExecutorService workExecutor = new ScheduledThreadPoolExecutor(1);
 
@@ -104,6 +106,8 @@ public class BatcherTest extends LiteTestCase {
         boolean didNotTimeOut = doneSignal.await(35, TimeUnit.SECONDS);
         assertTrue(didNotTimeOut);
 
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     /**
@@ -182,7 +186,8 @@ public class BatcherTest extends LiteTestCase {
         batcher.waitForPendingFutures();
         Log.d(TAG, "/waiting for pending futures");
 
-
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     /**
@@ -229,9 +234,9 @@ public class BatcherTest extends LiteTestCase {
             assertTrue(delta > 0);
             assertTrue(delta >= processorDelay);
 
+            // Note: ExecutorService should be called shutdown()
+            Utils.shutdownAndAwaitTermination(workExecutor);
         }
-
-
     }
 
 
@@ -291,6 +296,9 @@ public class BatcherTest extends LiteTestCase {
             // we shouldn't see latch close until processorDelay milliseconds has passed
             success = latch2.await(5, TimeUnit.SECONDS);
             assertTrue(success);
+
+            // Note: ExecutorService should be called shutdown()
+            Utils.shutdownAndAwaitTermination(workExecutor);
         }
     }
 
@@ -333,6 +341,9 @@ public class BatcherTest extends LiteTestCase {
 
         // at this point, the countdown latch should be 0
         assertEquals(0, latch.getCount());
+
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     /**
@@ -366,10 +377,11 @@ public class BatcherTest extends LiteTestCase {
             }
         });
 
+        final CountDownLatch monitorThread = new CountDownLatch(1);
         Thread t = new Thread(new Runnable() {
             @Override
             public void run() {
-                for (int i=0; i<numItemsToSubmit; i++) {
+                for (int i = 0; i < numItemsToSubmit; i++) {
 
                     if (i == inboxCapacity) {
                         latchSubmittedCapacity.countDown();
@@ -380,6 +392,7 @@ public class BatcherTest extends LiteTestCase {
                     batcher.queueObjects(objectsToQueue);
                     Log.d(TAG, "Submitted object %d", i);
                 }
+                monitorThread.countDown();;
             }
         });
         t.start();
@@ -389,13 +402,21 @@ public class BatcherTest extends LiteTestCase {
 
         // since we've already submitted up to capacity, our processor should
         // be called nearly immediately afterwards
-        success = latchFirstProcess.await(jobDelay * 2, TimeUnit.MILLISECONDS);
+        // NOTE: latchFirstProcess should be 0 this point in general, but this is not guaranteed.
+        //       Give more time. 1sec instead of 100ms
+        //       https://github.com/couchbase/couchbase-lite-java-core/issues/521
+        success = latchFirstProcess.await(jobDelay * 20, TimeUnit.MILLISECONDS);
         assertTrue(success);
 
         // we should not have been interrupted either
         assertEquals(latchInterrupted.getCount(), 1);
 
         t.interrupt();
+
+        monitorThread.await();
+
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     private static void assertNumbersConsecutive(List<String> itemsToProcess) {


### PR DESCRIPTION
...tInvokeProcessorAfterReachingCapacity()

- Task might not be completed in 100ms. new code waits 1sec instead of 100ms
- In addition to fix the issue, changed all codes to shutdown WorkExecutor for better termination logic.