### PR TITLE
Fixed CBL Java Core 522

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ManagerTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ManagerTest.java
@@ -6,6 +6,7 @@ import com.couchbase.lite.mockserver.MockDispatcher;
 import com.couchbase.lite.mockserver.MockHelper;
 import com.couchbase.lite.replicator.Replication;
 import com.couchbase.lite.util.Log;
+import com.couchbase.lite.util.Utils;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 
 import java.io.File;
@@ -165,7 +166,9 @@ public class ManagerTest extends LiteTestCase {
             if (a != null) {
                 a.delete();
             }
-            executorService.shutdown();
+
+            // Note: ExecutorService should be called shutdown()
+            Utils.shutdownAndAwaitTermination(executorService);
         }
     }
 

--- a/src/androidTest/java/com/couchbase/lite/replicator/BulkDownloaderTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/BulkDownloaderTest.java
@@ -1,10 +1,8 @@
 package com.couchbase.lite.replicator;
 
-import com.couchbase.lite.CouchbaseLiteException;
 import com.couchbase.lite.Database;
 import com.couchbase.lite.Document;
 import com.couchbase.lite.LiteTestCase;
-import com.couchbase.lite.Status;
 import com.couchbase.lite.internal.RevisionInternal;
 import com.couchbase.lite.mockserver.MockDispatcher;
 import com.couchbase.lite.mockserver.MockHelper;
@@ -12,8 +10,8 @@ import com.couchbase.lite.mockserver.WrappedSmartMockResponse;
 import com.couchbase.lite.support.CouchbaseLiteHttpClientFactory;
 import com.couchbase.lite.support.PersistentCookieStore;
 import com.couchbase.lite.support.RemoteRequestCompletionBlock;
-import com.couchbase.lite.support.RemoteRequestRetry;
 import com.couchbase.lite.util.Log;
+import com.couchbase.lite.util.Utils;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 
@@ -104,6 +102,10 @@ public class BulkDownloaderTest extends LiteTestCase {
 
         // wait for the future to return
         future.get(300, TimeUnit.SECONDS);
+
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(requestExecutorService);
+        Utils.shutdownAndAwaitTermination(workExecutorService);
 
         server.shutdown();
 

--- a/src/androidTest/java/com/couchbase/lite/support/BatcherTest.java
+++ b/src/androidTest/java/com/couchbase/lite/support/BatcherTest.java
@@ -3,6 +3,7 @@ package com.couchbase.lite.support;
 import com.couchbase.lite.Database;
 import com.couchbase.lite.LiteTestCase;
 import com.couchbase.lite.util.Log;
+import com.couchbase.lite.util.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -55,6 +56,8 @@ public class BatcherTest extends LiteTestCase {
         boolean didNotTimeOut = doneSignal.await(35, TimeUnit.SECONDS);
         assertTrue(didNotTimeOut);
 
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     /**
@@ -63,7 +66,6 @@ public class BatcherTest extends LiteTestCase {
      * Also make sure that they appear in the correct order within a batch.
      */
     public void testBatcherBatchSize5() throws Exception {
-
 
         ScheduledExecutorService workExecutor = new ScheduledThreadPoolExecutor(1);
 
@@ -104,6 +106,8 @@ public class BatcherTest extends LiteTestCase {
         boolean didNotTimeOut = doneSignal.await(35, TimeUnit.SECONDS);
         assertTrue(didNotTimeOut);
 
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     /**
@@ -182,7 +186,8 @@ public class BatcherTest extends LiteTestCase {
         batcher.waitForPendingFutures();
         Log.d(TAG, "/waiting for pending futures");
 
-
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     /**
@@ -229,9 +234,9 @@ public class BatcherTest extends LiteTestCase {
             assertTrue(delta > 0);
             assertTrue(delta >= processorDelay);
 
+            // Note: ExecutorService should be called shutdown()
+            Utils.shutdownAndAwaitTermination(workExecutor);
         }
-
-
     }
 
 
@@ -291,6 +296,9 @@ public class BatcherTest extends LiteTestCase {
             // we shouldn't see latch close until processorDelay milliseconds has passed
             success = latch2.await(5, TimeUnit.SECONDS);
             assertTrue(success);
+
+            // Note: ExecutorService should be called shutdown()
+            Utils.shutdownAndAwaitTermination(workExecutor);
         }
     }
 
@@ -333,6 +341,9 @@ public class BatcherTest extends LiteTestCase {
 
         // at this point, the countdown latch should be 0
         assertEquals(0, latch.getCount());
+
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     /**
@@ -366,10 +377,11 @@ public class BatcherTest extends LiteTestCase {
             }
         });
 
+        final CountDownLatch monitorThread = new CountDownLatch(1);
         Thread t = new Thread(new Runnable() {
             @Override
             public void run() {
-                for (int i=0; i<numItemsToSubmit; i++) {
+                for (int i = 0; i < numItemsToSubmit; i++) {
 
                     if (i == inboxCapacity) {
                         latchSubmittedCapacity.countDown();
@@ -380,6 +392,7 @@ public class BatcherTest extends LiteTestCase {
                     batcher.queueObjects(objectsToQueue);
                     Log.d(TAG, "Submitted object %d", i);
                 }
+                monitorThread.countDown();;
             }
         });
         t.start();
@@ -389,13 +402,21 @@ public class BatcherTest extends LiteTestCase {
 
         // since we've already submitted up to capacity, our processor should
         // be called nearly immediately afterwards
-        success = latchFirstProcess.await(jobDelay * 2, TimeUnit.MILLISECONDS);
+        // NOTE: latchFirstProcess should be 0 this point in general, but this is not guaranteed.
+        //       Give more time. 1sec instead of 100ms
+        //       https://github.com/couchbase/couchbase-lite-java-core/issues/521
+        success = latchFirstProcess.await(jobDelay * 20, TimeUnit.MILLISECONDS);
         assertTrue(success);
 
         // we should not have been interrupted either
         assertEquals(latchInterrupted.getCount(), 1);
 
         t.interrupt();
+
+        monitorThread.await();
+
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(workExecutor);
     }
 
     private static void assertNumbersConsecutive(List<String> itemsToProcess) {

--- a/src/androidTest/java/com/couchbase/lite/support/BatcherTest.java
+++ b/src/androidTest/java/com/couchbase/lite/support/BatcherTest.java
@@ -402,10 +402,7 @@ public class BatcherTest extends LiteTestCase {
 
         // since we've already submitted up to capacity, our processor should
         // be called nearly immediately afterwards
-        // NOTE: latchFirstProcess should be 0 this point in general, but this is not guaranteed.
-        //       Give more time. 1sec instead of 100ms
-        //       https://github.com/couchbase/couchbase-lite-java-core/issues/521
-        success = latchFirstProcess.await(jobDelay * 20, TimeUnit.MILLISECONDS);
+        success = latchFirstProcess.await(jobDelay * 2, TimeUnit.MILLISECONDS);
         assertTrue(success);
 
         // we should not have been interrupted either

--- a/src/androidTest/java/com/couchbase/lite/support/RemoteRequestTest.java
+++ b/src/androidTest/java/com/couchbase/lite/support/RemoteRequestTest.java
@@ -5,9 +5,8 @@ import com.couchbase.lite.LiteTestCase;
 import com.couchbase.lite.mockserver.MockCheckpointPut;
 import com.couchbase.lite.mockserver.MockDispatcher;
 import com.couchbase.lite.mockserver.MockHelper;
-import com.couchbase.lite.mockserver.MockRevsDiff;
 import com.couchbase.lite.mockserver.WrappedSmartMockResponse;
-import com.couchbase.lite.util.Log;
+import com.couchbase.lite.util.Utils;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.MockWebServer;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
@@ -21,11 +20,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 public class RemoteRequestTest extends LiteTestCase {
@@ -85,7 +82,6 @@ public class RemoteRequestTest extends LiteTestCase {
         ScheduledExecutorService requestExecutorService = Executors.newScheduledThreadPool(5);
         ScheduledExecutorService workExecutorService = Executors.newSingleThreadScheduledExecutor();
 
-        // ScheduledExecutorService executorService = new ScheduledThreadPoolExecutor(4);
         RemoteRequestRetry request = new RemoteRequestRetry(
                 RemoteRequestRetry.RemoteRequestType.REMOTE_REQUEST,
                 requestExecutorService,
@@ -114,6 +110,9 @@ public class RemoteRequestTest extends LiteTestCase {
             assertNotNull(recordedRequest);
         }
 
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(requestExecutorService);
+        Utils.shutdownAndAwaitTermination(workExecutorService);
     }
 
 
@@ -193,6 +192,9 @@ public class RemoteRequestTest extends LiteTestCase {
             assertNotNull(recordedRequest);
         }
 
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(requestExecutorService);
+        Utils.shutdownAndAwaitTermination(workExecutorService);
     }
 
 
@@ -275,7 +277,6 @@ public class RemoteRequestTest extends LiteTestCase {
 
             Future future = request.submit();
             requestFutures.add(future);
-
         }
 
         for (Future future : requestFutures) {
@@ -285,14 +286,8 @@ public class RemoteRequestTest extends LiteTestCase {
         boolean success = received503Error.await(120, TimeUnit.SECONDS);
         assertTrue(success);
 
-
-
-
-
-
+        // Note: ExecutorService should be called shutdown()
+        Utils.shutdownAndAwaitTermination(requestExecutorService);
+        Utils.shutdownAndAwaitTermination(workExecutorService);
     }
-
-
-
-
 }


### PR DESCRIPTION
- Calls ExecutorService.shutdown() whenever test uses ExecutorService. Without calling shoutdown(), ExecutorService might cause thread-leak.