### PR TITLE
Test userinfo in BasicAuthenticator is encoded.

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/AuthTest.java
+++ b/src/androidTest/java/com/couchbase/lite/AuthTest.java
@@ -78,10 +78,28 @@ public class AuthTest extends TestCase {
     public void testBasicAuthenticator() {
         String username = "username";
         String password = "password";
+        String expectedAuthInfo = username + ":" + password;
         BasicAuthenticator basicAuth = new BasicAuthenticator(username, password);
 
         Assert.assertNull(basicAuth.loginParametersForSite(null));
         Assert.assertTrue(basicAuth.usesCookieBasedLogin());
-        Assert.assertEquals(basicAuth.authUserInfo(), username + ":" + password);
+        Assert.assertEquals(basicAuth.authUserInfo(), expectedAuthInfo);
+
+        // Test encoding of authUserInfo
+        // Username with reserved characters from RFC 3986
+        // Password with unreserved characters
+        username = "/?#:[]@";
+        password = "aAwWzZ190-._~";
+        expectedAuthInfo = "%2F%3F%23%3A%5B%5D%40" + ":" + password;
+        basicAuth = new BasicAuthenticator(username, password);
+        Assert.assertEquals(basicAuth.authUserInfo(), expectedAuthInfo);
+
+        // Also test with some UTF-8 characters
+        username = "七乃又直ந்த";
+        password = "ؤلمن:يстекло";
+        expectedAuthInfo = "%E4%B8%83%E4%B9%83%E5%8F%88%E7%9B%B4%E0%AE%A8%E0%AF%8D%E0%AE%A4"
+                + ":" + "%D8%A4%D9%84%D9%85%D9%86%3A%D9%8A%D1%81%D1%82%D0%B5%D0%BA%D0%BB%D0%BE";
+        basicAuth = new BasicAuthenticator(username, password);
+        Assert.assertEquals(basicAuth.authUserInfo(), expectedAuthInfo);
     }
 }

--- a/src/androidTest/java/com/couchbase/lite/LiteTestCase.java
+++ b/src/androidTest/java/com/couchbase/lite/LiteTestCase.java
@@ -15,6 +15,7 @@ import com.couchbase.lite.router.URLStreamHandlerFactory;
 import com.couchbase.lite.storage.Cursor;
 import com.couchbase.lite.support.HttpClientFactory;
 import com.couchbase.lite.util.Log;
+import com.couchbase.lite.util.URIUtils;
 import com.couchbase.test.lite.LiteTestCaseBase;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -172,7 +173,9 @@ public class LiteTestCase extends LiteTestCaseBase {
     protected URL getReplicationURL()  {
         try {
             if(getReplicationAdminUser() != null && getReplicationAdminUser().trim().length() > 0) {
-                return new URL(String.format("%s://%s:%s@%s:%d/%s", getReplicationProtocol(), getReplicationAdminUser(), getReplicationAdminPassword(), getReplicationServer(), getReplicationPort(), getReplicationDatabase()));
+                String encodedUserName = URIUtils.encode(getReplicationAdminUser());
+                String encodedPassword = URIUtils.encode(getReplicationAdminPassword());
+                return new URL(String.format("%s://%s:%s@%s:%d/%s", getReplicationProtocol(), encodedUserName, encodedPassword, getReplicationServer(), getReplicationPort(), getReplicationDatabase()));
             } else {
                 return new URL(String.format("%s://%s:%d/%s", getReplicationProtocol(), getReplicationServer(), getReplicationPort(), getReplicationDatabase()));
             }
@@ -184,7 +187,9 @@ public class LiteTestCase extends LiteTestCaseBase {
     protected URL getReplicationSubURL(String subIndex)  {
         try {
             if(getReplicationAdminUser() != null && getReplicationAdminUser().trim().length() > 0) {
-                return new URL(String.format("%s://%s:%s@%s:%d/%s%s", getReplicationProtocol(), getReplicationAdminUser(), getReplicationAdminPassword(), getReplicationServer(), getReplicationPort(), getReplicationDatabase(),subIndex));
+                String encodedUserName = URIUtils.encode(getReplicationAdminUser());
+                String encodedPassword = URIUtils.encode(getReplicationAdminPassword());
+                return new URL(String.format("%s://%s:%s@%s:%d/%s%s", getReplicationProtocol(), encodedUserName, encodedPassword, getReplicationServer(), getReplicationPort(), getReplicationDatabase(),subIndex));
             } else {
                 return new URL(String.format("%s://%s:%d/%s%s", getReplicationProtocol(), getReplicationServer(), getReplicationPort(), getReplicationDatabase(),subIndex));
             }


### PR DESCRIPTION
When needed, according to RFC 3986.

Unit tests for couchbase/couchbase-lite-java-core#568