### PR TITLE
Fixed #613

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ApiTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ApiTest.java
@@ -929,6 +929,11 @@ public class ApiTest extends LiteTestCase {
         // stop the livequery since we are done with it
         query.removeChangeListener(changeListener);
         query.stop();
+
+        // Workaround for https://github.com/couchbase/couchbase-lite-android/issues/613
+        try {
+            Thread.sleep(2 * 1000);
+        }catch(Exception e){}
     }
 
     public void testAsyncViewQuery() throws Exception {


### PR DESCRIPTION
- LiveQuery.stop() is asynchronous method. When tearDown() tries to close database, liveQuery is still running, and fails to close database. As workaround, give 2sec to finish LiveQuery.stop().