### PR TITLE
Fixed #616 - CBL Java: `ManagerTest.testServer()` and `testClose()` unit tests fail on Windows

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ManagerTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ManagerTest.java
@@ -46,7 +46,7 @@ public class ManagerTest extends LiteTestCase {
         Database db = manager.getDatabaseWithoutOpening("foo", mustExist);
         assertNotNull(db);
         assertEquals("foo", db.getName());
-        assertTrue(db.getPath().startsWith(new LiteTestContext().getRootDirectory().getAbsolutePath()));
+        assertTrue(db.getPath().startsWith(new LiteTestContext(false).getRootDirectory().getAbsolutePath()));
         assertFalse(db.exists());
 
 

--- a/src/androidTest/java/com/couchbase/lite/mockserver/MockDispatcher.java
+++ b/src/androidTest/java/com/couchbase/lite/mockserver/MockDispatcher.java
@@ -63,7 +63,7 @@ public class MockDispatcher extends Dispatcher {
     }
 
     @Override
-    public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+    public synchronized MockResponse dispatch(RecordedRequest request) throws InterruptedException {
         System.out.println(String.format("Request: %s", request));
         for(String pathRegex: queueMap.keySet()){
             if (regexMatches(pathRegex, request.getPath())) {


### PR DESCRIPTION
- new LiteTestContext() tries to delete all sub-directories, but they are in use. Use new LiteTextContext(false) to not try to delete sub-folders.
- Because of race condition, MockDispatcher.dispatch() should be synchronized.