### PR TITLE
Fixed Java Core 636: Exel: Push replication "losing" documents create…

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.couchbase.lite">
 
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
     <application />
 

--- a/src/main/java/com/couchbase/lite/android/AndroidNetworkReachabilityManager.java
+++ b/src/main/java/com/couchbase/lite/android/AndroidNetworkReachabilityManager.java
@@ -4,43 +4,22 @@ import android.content.BroadcastReceiver;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.net.ConnectivityManager;
+import android.net.NetworkInfo;
 
-import com.couchbase.lite.Context;
 import com.couchbase.lite.NetworkReachabilityManager;
 import com.couchbase.lite.util.Log;
 
 public class AndroidNetworkReachabilityManager extends NetworkReachabilityManager {
 
-    private Context context;
     private boolean listening;
     private android.content.Context wrappedContext;
     private ConnectivityBroadcastReceiver receiver;
-    private State state;
 
-    public enum State {
-        UNKNOWN,
-
-        /** This state is returned if there is connectivity to any network **/
-        CONNECTED,
-        /**
-         * This state is returned if there is no connectivity to any network. This is set to true
-         * under two circumstances:
-         * <ul>
-         * <li>When connectivity is lost to one network, and there is no other available network to
-         * attempt to switch to.</li>
-         * <li>When connectivity is lost to one network, and the attempt to switch to another
-         * network fails.</li>
-         */
-        NOT_CONNECTED
-    }
-
-    public AndroidNetworkReachabilityManager(AndroidContext context) {
-        this.context = context;
-        this.wrappedContext = context.getWrappedContext();
+    public AndroidNetworkReachabilityManager(AndroidContext androidContextcontext) {
+        this.listening = false;
+        this.wrappedContext = androidContextcontext.getWrappedContext();
         this.receiver = new ConnectivityBroadcastReceiver();
-        this.state = State.UNKNOWN;
     }
-
 
     public synchronized void startListening() {
         if (!listening) {
@@ -60,38 +39,30 @@ public class AndroidNetworkReachabilityManager extends NetworkReachabilityManage
             } catch (Exception e) {
                 Log.e(Log.TAG_SYNC, "%s: stopListening() exception unregistering %s with context %s", e, this, receiver, wrappedContext);
             }
-            context = null;
             listening = false;
         }
     }
 
     private class ConnectivityBroadcastReceiver extends BroadcastReceiver {
-
         @Override
         public void onReceive(android.content.Context context, Intent intent) {
             String action = intent.getAction();
-
             if (!action.equals(ConnectivityManager.CONNECTIVITY_ACTION) || listening == false) {
                 return;
             }
 
-            boolean noConnectivity = intent.getBooleanExtra(ConnectivityManager.EXTRA_NO_CONNECTIVITY, false);
-
-            if (noConnectivity) {
-                state = State.NOT_CONNECTED;
+            Log.e(Log.TAG_SYNC, "BroadcastReceiver.onReceive() isOnline(context)=" + isOnline(context));
+            if (isOnline(context)) {
+                notifyListenersNetworkReachable();
             } else {
-                state = State.CONNECTED;
-            }
-
-            if (state == State.NOT_CONNECTED) {
                 notifyListenersNetworkUneachable();
             }
-
-            if (state == State.CONNECTED) {
-                notifyListenersNetworkReachable();
-            }
-
         }
-    };
+    }
 
+    private boolean isOnline(android.content.Context context) {
+        ConnectivityManager cm = (ConnectivityManager) context.getSystemService(android.content.Context.CONNECTIVITY_SERVICE);
+        NetworkInfo activeNetwork = cm.getActiveNetworkInfo();
+        return activeNetwork != null && activeNetwork.isConnected();
+    }
 }

--- a/src/main/java/com/couchbase/lite/android/AndroidNetworkReachabilityManager.java
+++ b/src/main/java/com/couchbase/lite/android/AndroidNetworkReachabilityManager.java
@@ -51,8 +51,10 @@ public class AndroidNetworkReachabilityManager extends NetworkReachabilityManage
                 return;
             }
 
-            Log.e(Log.TAG_SYNC, "BroadcastReceiver.onReceive() isOnline(context)=" + isOnline(context));
-            if (isOnline(context)) {
+            boolean bOnline = isOnline(context);
+            Log.v(Log.TAG_SYNC, "BroadcastReceiver.onReceive() bOnline=" + bOnline);
+
+            if (bOnline) {
                 notifyListenersNetworkReachable();
             } else {
                 notifyListenersNetworkUneachable();


### PR DESCRIPTION
…d when disconnected

Java Core 636: https://github.com/couchbase/couchbase-lite-java-core/issues/636

From Lollipop, old style of accessing network connectivity does not work. Changed our code to use `ConnectivityManager`. In addition, I added `<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />`.

Test this codes with Nexus 6 (Android 5.1), Nexus 5 (Android 5.0), and Motorola Xoom (Android 4.1.2)