### PR TITLE
Fixed Java Core issue 740 (ChangesTest failure)

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ChangesTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ChangesTest.java
@@ -12,6 +12,7 @@ public class ChangesTest extends LiteTestCase {
     private int changeNotifications = 0;
 
     public void testChangeNotification() throws CouchbaseLiteException {
+        changeNotifications = 0;
 
         Database.ChangeListener changeListener = new Database.ChangeListener() {
             @Override


### PR DESCRIPTION
- By run both ForestDB and SQLite, UnitTest instance variable should be reset for each test.