### PR TITLE
Implement insertOrThrow of SQLiteStorageEngine

### DIFF
--- a/src/main/java/com/couchbase/lite/android/AndroidSQLCipherStorageEngine.java
+++ b/src/main/java/com/couchbase/lite/android/AndroidSQLCipherStorageEngine.java
@@ -42,7 +42,7 @@ public class AndroidSQLCipherStorageEngine implements SQLiteStorageEngine {
         try {
             database = SQLiteDatabase.openDatabase(path, null, SQLiteDatabase.CREATE_IF_NECESSARY);
             Log.v(Log.TAG_DATABASE, "%s: Opened Android sqlite db", this);
-        } catch(Throwable e) {
+        } catch(com.couchbase.lite.database.SQLException e) {
             Log.e(Log.TAG_DATABASE, "Unable to open the SQLite database", e);
             if (database != null)
                 database.close();
@@ -85,7 +85,7 @@ public class AndroidSQLCipherStorageEngine implements SQLiteStorageEngine {
     public void execSQL(String sql) throws SQLException {
         try {
             database.execSQL(sql);
-        } catch (Exception e) {
+        } catch (com.couchbase.lite.database.SQLException e) {
             throw new SQLException(e);
         }
     }
@@ -94,7 +94,7 @@ public class AndroidSQLCipherStorageEngine implements SQLiteStorageEngine {
     public void execSQL(String sql, Object[] bindArgs) throws SQLException {
         try {
             database.execSQL(sql, bindArgs);
-        } catch (Exception e) {
+        } catch (com.couchbase.lite.database.SQLException e) {
             throw new SQLException(e);
         }
     }
@@ -107,6 +107,15 @@ public class AndroidSQLCipherStorageEngine implements SQLiteStorageEngine {
     @Override
     public long insert(String table, String nullColumnHack, ContentValues values) {
         return database.insert(table, nullColumnHack, toContentValues(values));
+    }
+
+    @Override
+    public long insertOrThrow(String table, String nullColumnHack, ContentValues values) throws SQLException {
+        try {
+            return database.insertOrThrow(table, nullColumnHack, toContentValues(values));
+        } catch (com.couchbase.lite.database.SQLException e) {
+            throw new SQLException(e);
+        }
     }
 
     @Override

--- a/src/main/java/com/couchbase/lite/android/AndroidSQLiteStorageEngine.java
+++ b/src/main/java/com/couchbase/lite/android/AndroidSQLiteStorageEngine.java
@@ -128,6 +128,15 @@ public class AndroidSQLiteStorageEngine implements SQLiteStorageEngine {
     }
 
     @Override
+    public long insertOrThrow(String table, String nullColumnHack, ContentValues values) throws SQLException {
+        try {
+            return database.insertOrThrow(table, nullColumnHack, AndroidSQLiteHelper.toAndroidContentValues(values));
+        } catch (android.database.SQLException e) {
+            throw new SQLException(e);
+        }
+    }
+
+    @Override
     public long insertWithOnConflict(String table, String nullColumnHack,
                                      ContentValues initialValues, int conflictAlgorithm) {
         return database.insertWithOnConflict(table, nullColumnHack,


### PR DESCRIPTION
- Implemented insertOrThrow method of the SQLiteStorageEngine interface
- On AndroidSQLCipherStorageEngine, instead of caching a generic exception, caching com.couchbase.lite.database.SQLException instead.