### PR TITLE
Fixed #749 slowness in testSymmetricKey and testCompactEncryptedDB test

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/BlobStoreTest.java
+++ b/src/androidTest/java/com/couchbase/lite/BlobStoreTest.java
@@ -41,8 +41,7 @@ public class BlobStoreTest extends LiteTestCaseWithDB {
     public void runBare() throws Throwable {
         encrypt = false;
         super.runBare();
-        if(!isAndriod())
-            return;
+
         encrypt = true;
         super.runBare();
     }
@@ -85,7 +84,7 @@ public class BlobStoreTest extends LiteTestCaseWithDB {
     }
 
     public void testBasic() throws Exception {
-        if (!isSQLiteDB() || !isAndriod()) return;
+        if (!isSQLiteDB()) return;
 
         byte[] item = "this is an item".getBytes("UTF8");
         BlobKey key = new BlobKey();
@@ -103,7 +102,7 @@ public class BlobStoreTest extends LiteTestCaseWithDB {
     }
 
     public void testReopen() throws Exception {
-        if (!isSQLiteDB() || !isAndriod()) return;
+        if (!isSQLiteDB()) return;
 
         byte[] item = "this is an item".getBytes("UTF8");
         BlobKey key = new BlobKey();
@@ -121,7 +120,7 @@ public class BlobStoreTest extends LiteTestCaseWithDB {
     }
 
     public void testBlobStoreWriter() throws Exception {
-        if (!isSQLiteDB() || !isAndriod()) return;
+        if (!isSQLiteDB()) return;
 
         BlobStoreWriter writer = new BlobStoreWriter(store);
         Assert.assertNotNull(writer);

--- a/src/androidTest/java/com/couchbase/lite/MiscTest.java
+++ b/src/androidTest/java/com/couchbase/lite/MiscTest.java
@@ -1,3 +1,19 @@
+/**
+ *
+ * Copyright (c) 2015 Couchbase, Inc All rights reserved.
+ * <p/>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of the License at
+ * <p/>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p/>
+ * Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing permissions
+ * and limitations under the License.
+ *
+ */
+
 package com.couchbase.lite;
 
 import com.couchbase.lite.support.security.SymmetricKey;
@@ -18,13 +34,11 @@ public class MiscTest extends LiteTestCase {
     }
 
     public void testSymmetricKey() throws Exception {
-        if (!isAndriod()) return;
-
+        long start = System.currentTimeMillis();
         // Generate a key from a password:
         String password = "letmein123456";
         byte[] salt = "SaltyMcNaCl".getBytes();
 
-        long start = System.currentTimeMillis();
         SymmetricKey key = new SymmetricKey(password, salt, 1024);
         long end = System.currentTimeMillis();
         Log.i(TAG, "Finished getting a symmetric key in " + (end - start) + " msec.");
@@ -43,11 +57,12 @@ public class MiscTest extends LiteTestCase {
         Assert.assertTrue(Arrays.equals(clearText, decrypted));
 
         // Incremental encryption:
+        start = System.currentTimeMillis();
         SymmetricKey.Encryptor encryptor = key.createEncryptor();
         byte[] incrementalClearText = new byte[0];
         byte[] incrementalCiphertext = new byte[0];
-        for (int i = 0; i < 100; i++) {
-            byte[] data = new SecureRandom().generateSeed(5555);
+        for (int i = 0; i < 55; i++) {
+            byte[] data = new SecureRandom().generateSeed(555);
             byte[] cipherData = encryptor.encrypt(data);
             incrementalClearText = ArrayUtils.concat(incrementalClearText, data);
             incrementalCiphertext = ArrayUtils.concat(incrementalCiphertext, cipherData);
@@ -55,5 +70,7 @@ public class MiscTest extends LiteTestCase {
         incrementalCiphertext = ArrayUtils.concat(incrementalCiphertext, encryptor.encrypt(null));
         decrypted = key.decryptData(incrementalCiphertext);
         Assert.assertTrue(Arrays.equals(incrementalClearText, decrypted));
+        end = System.currentTimeMillis();
+        Log.i(TAG, "Finished incremental encryption test in " + (end - start) + " msec.");
     }
 }


### PR DESCRIPTION
- Improved performance in testSymmetricKey and testCompactEncryptedDB

- Enabled BlobStoreTest and DatabaseEncryptionTest for Java

https://github.com/couchbase/couchbase-lite-java-core/issues/748
https://github.com/couchbase/couchbase-lite-java-core/issues/749
https://github.com/couchbase/couchbase-lite-java-core/issues/760