### PR TITLE
Fixed MiscTeset.testSymmetricKey hang on linux 

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/MiscTest.java
+++ b/src/androidTest/java/com/couchbase/lite/MiscTest.java
@@ -68,8 +68,10 @@ public class MiscTest extends LiteTestCase {
         SymmetricKey.Encryptor encryptor = key.createEncryptor();
         byte[] incrementalClearText = new byte[0];
         byte[] incrementalCiphertext = new byte[0];
+        SecureRandom random = new SecureRandom();
         for (int i = 0; i < 55; i++) {
-            byte[] data = new SecureRandom().generateSeed(555);
+            byte[] data = new byte[555];
+            random.nextBytes(data);
             byte[] cipherData = encryptor.encrypt(data);
             incrementalClearText = ArrayUtils.concat(incrementalClearText, data);
             incrementalCiphertext = ArrayUtils.concat(incrementalCiphertext, cipherData);
@@ -79,5 +81,16 @@ public class MiscTest extends LiteTestCase {
         Assert.assertTrue(Arrays.equals(incrementalClearText, decrypted));
         end = System.currentTimeMillis();
         Log.i(TAG, "Finished incremental encryption test in " + (end - start) + " msec.");
+    }
+
+    public void testCreateRandomSymmetricKey() throws Exception {
+        long start = System.currentTimeMillis();
+        SymmetricKey key = new SymmetricKey();
+        long end = System.currentTimeMillis();
+        Log.i(TAG, "Finished creating a random symmetric key in " + (end - start) + " msec.");
+        byte[] keyData = key.getKey();
+        Assert.assertNotNull(keyData);
+        Assert.assertEquals(32, keyData.length);
+        Log.i(TAG, "Key = " + key);
     }
 }


### PR DESCRIPTION
- Instead of using SecureRandom.genearteSeed(), use nextBytes() instead.

- Added testCreateRandomSymmetricKey() to make sure that there is no SecureRandom issue in the SymmetricKey class.

- Tested on OSX (Java 1.8), Ubuntu Linux (Open Java 1.7), Windows Server 2002 (Java 8), and Android.

https://github.com/couchbase/couchbase-lite-java-core/issues/769