### PR TITLE
Update unit tests for close database fix

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/DatabaseEncryptionTest.java
+++ b/src/androidTest/java/com/couchbase/lite/DatabaseEncryptionTest.java
@@ -216,8 +216,11 @@ public class DatabaseEncryptionTest extends LiteTestCaseWithDB {
             }
         });
 
-        // Close and reopen:
+        // Close and then reopen the database:
         Assert.assertTrue(seekrit.close());
+        // Reregister the encryption key:
+        cryptoManager.registerEncryptionKey("letmein", "seekrit");
+        // Reopen the database:
         seekrit = cryptoManager.getDatabase("seekrit");
         Assert.assertNotNull(seekrit);
         Assert.assertEquals(1, seekrit.getDocumentCount());

--- a/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -227,4 +227,26 @@ public class DatabaseTest extends LiteTestCaseWithDB {
         }));
         assertTrue(latch.await(0, TimeUnit.SECONDS));
     }
+
+    public void testClose() throws Exception {
+        // Get the database:
+        Database db = manager.getDatabase(DEFAULT_TEST_DB);
+        assertNotNull(db);
+        // Test that the database is remembered by the manager:
+        assertEquals(db, manager.getDatabase(DEFAULT_TEST_DB));
+        assertTrue(manager.allOpenDatabases().contains(db));
+
+        // Create a new document:
+        Document doc = db.getDocument("doc1");
+        assertNotNull(doc.putProperties(new HashMap<String, Object>()));
+        // Test that the document is remebered by the database:
+        assertEquals(doc, db.getCachedDocument("doc1"));
+
+        // Close database:
+        database.close();
+        // The cache should be clear:
+        assertNull(db.getCachedDocument("doc1"));
+        // This that the database is forgotten:
+        assertFalse(manager.allOpenDatabases().contains(db));
+    }
 }


### PR DESCRIPTION
- Added testClose to DatabaseTest.
- Fixed DatabaseEncruptionTest.testCompactEncryptedDB to reregister the encryption key after closing the database.

https://github.com/couchbase/couchbase-lite-java-core/issues/780