### PR TITLE
Implement key derivation at the storage engine

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/DatabaseEncryptionTest.java
+++ b/src/androidTest/java/com/couchbase/lite/DatabaseEncryptionTest.java
@@ -17,14 +17,16 @@
 
 package com.couchbase.lite;
 
+import com.couchbase.lite.support.security.SymmetricKey;
+import com.couchbase.lite.util.ArrayUtils;
 import com.couchbase.lite.util.Log;
 import com.couchbase.lite.util.TextUtils;
 
 import junit.framework.Assert;
 
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.io.FileInputStream;
+import java.security.SecureRandom;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -47,6 +49,58 @@ public class DatabaseEncryptionTest extends LiteTestCaseWithDB {
         super.tearDown();
         if (cryptoManager != null)
             cryptoManager.close();
+    }
+
+    public void testSymmetricKey() throws Exception {
+        Database database = cryptoManager.getDatabase("seekrit");
+
+        long start = System.currentTimeMillis();
+        SymmetricKey key = database.createSymmetricKey("letmein123456");
+        long end = System.currentTimeMillis();
+        Log.i(TAG, "Finished getting a symmetric key in " + (end - start) + " msec.");
+        byte[] keyData = key.getKey();
+        Log.i(TAG, "Key = " + key);
+
+        // Encrypt using the key:
+        byte[] clearText = "This is the clear text.".getBytes();
+        byte[] ciphertext = key.encryptData(clearText);
+        Log.i(TAG, "Encrypted = " + new String(ciphertext));
+        Assert.assertNotNull(ciphertext);
+
+        // Decrypt using the key:
+        byte[] decrypted = key.decryptData(ciphertext);
+        Log.i(TAG, "Decrypted String = " + new String(decrypted));
+        Assert.assertTrue(Arrays.equals(clearText, decrypted));
+
+        // Incremental encryption:
+        start = System.currentTimeMillis();
+        SymmetricKey.Encryptor encryptor = key.createEncryptor();
+        byte[] incrementalClearText = new byte[0];
+        byte[] incrementalCiphertext = new byte[0];
+        SecureRandom random = new SecureRandom();
+        for (int i = 0; i < 55; i++) {
+            byte[] data = new byte[555];
+            random.nextBytes(data);
+            byte[] cipherData = encryptor.encrypt(data);
+            incrementalClearText = ArrayUtils.concat(incrementalClearText, data);
+            incrementalCiphertext = ArrayUtils.concat(incrementalCiphertext, cipherData);
+        }
+        incrementalCiphertext = ArrayUtils.concat(incrementalCiphertext, encryptor.encrypt(null));
+        decrypted = key.decryptData(incrementalCiphertext);
+        Assert.assertTrue(Arrays.equals(incrementalClearText, decrypted));
+        end = System.currentTimeMillis();
+        Log.i(TAG, "Finished incremental encryption test in " + (end - start) + " msec.");
+    }
+
+    public void testCreateRandomSymmetricKey() throws Exception {
+        long start = System.currentTimeMillis();
+        SymmetricKey key = new SymmetricKey();
+        long end = System.currentTimeMillis();
+        Log.i(TAG, "Finished creating a random symmetric key in " + (end - start) + " msec.");
+        byte[] keyData = key.getKey();
+        Assert.assertNotNull(keyData);
+        Assert.assertEquals(32, keyData.length);
+        Log.i(TAG, "Key = " + key);
     }
 
     public void testEncryptionFailsGracefully() throws Exception {

--- a/src/androidTest/java/com/couchbase/lite/support/ActionTest.java
+++ b/src/androidTest/java/com/couchbase/lite/support/ActionTest.java
@@ -15,8 +15,9 @@
  *
  */
 
-package com.couchbase.lite;
+package com.couchbase.lite.support;
 
+import com.couchbase.lite.LiteTestCase;
 import com.couchbase.lite.support.action.Action;
 import com.couchbase.lite.support.action.ActionBlock;
 import com.couchbase.lite.support.action.ActionException;

--- a/src/main/java/com/couchbase/lite/android/AndroidSQLCipherStorageEngine.java
+++ b/src/main/java/com/couchbase/lite/android/AndroidSQLCipherStorageEngine.java
@@ -16,6 +16,7 @@
 
 package com.couchbase.lite.android;
 
+import com.couchbase.lite.database.security.Key;
 import com.couchbase.lite.storage.ContentValues;
 import com.couchbase.lite.storage.Cursor;
 import com.couchbase.lite.storage.SQLException;
@@ -27,8 +28,6 @@ import com.couchbase.lite.database.sqlite.SQLiteDatabase;
 import java.util.Map;
 
 public class AndroidSQLCipherStorageEngine implements SQLiteStorageEngine {
-    private static final boolean SUPPORT_ENCRYPTION = true;
-
     private SQLiteDatabase database;
 
     public AndroidSQLCipherStorageEngine() {
@@ -63,7 +62,7 @@ public class AndroidSQLCipherStorageEngine implements SQLiteStorageEngine {
 
     @Override
     public boolean isOpen() {
-        return database.isOpen();
+        return database != null && database.isOpen();
     }
 
     @Override
@@ -143,8 +142,14 @@ public class AndroidSQLCipherStorageEngine implements SQLiteStorageEngine {
         database.close();
     }
 
+    @Override
     public boolean supportEncryption() {
-        return SUPPORT_ENCRYPTION;
+        return true;
+    }
+
+    @Override
+    public byte[] derivePBKDF2SHA256Key(String password, byte[] salt, int rounds) {
+        return Key.derivePBKDF2SHA256Key(password, salt, rounds);
     }
 
     @Override

--- a/src/main/java/com/couchbase/lite/android/AndroidSQLiteStorageEngine.java
+++ b/src/main/java/com/couchbase/lite/android/AndroidSQLiteStorageEngine.java
@@ -77,7 +77,7 @@ public class AndroidSQLiteStorageEngine implements SQLiteStorageEngine {
 
     @Override
     public boolean isOpen() {
-        return database.isOpen();
+        return database != null && database.isOpen();
     }
 
     @Override
@@ -166,6 +166,11 @@ public class AndroidSQLiteStorageEngine implements SQLiteStorageEngine {
     @Override
     public boolean supportEncryption() {
         return false;
+    }
+
+    @Override
+    public byte[] derivePBKDF2SHA256Key(String password, byte[] salt, int rounds) {
+        throw new UnsupportedOperationException("The storage doesn't support encryption");
     }
 
     @Override


### PR DESCRIPTION
- Used Key.derivePBKDF2SHA256Key() method implemented in couchbase-lite-java-sqlcipher to do key deriviation with libcrypto.

- Moved all SymmetricKey tests from MiscTest into DatabaseEncryptionTest.

- Moved ActionTest into support folder

https://github.com/couchbase/couchbase-lite-java-core/issues/805