### PR TITLE
Add an ability to enable and disable sqlcipher engine in unit tests

### DIFF
--- a/src/androidTest/assets/test.properties
+++ b/src/androidTest/assets/test.properties
@@ -9,3 +9,4 @@ replicationDatabase=db
 replicationAdminUser=
 replicationAdminPassword=
 syncgatewayTestsEnabled=false
+sqlcipherStorageEngineTestsEnabled=false

--- a/src/androidTest/java/com/couchbase/lite/DatabaseEncryptionTest.java
+++ b/src/androidTest/java/com/couchbase/lite/DatabaseEncryptionTest.java
@@ -32,16 +32,24 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class DatabaseEncryptionTest extends LiteTestCaseWithDB {
-    private static final String TEST_DIR = "encryption";
+    private static final String TEST_ENC_DIR = "encryption";
+    private static final String TEST_NONENC_DIR = "nonencryption";
     private static final String NULL_PASSWORD = null;
     private Manager cryptoManager;
+    private Manager nonCryptoManager;
 
     @Override
     protected void setUp() throws Exception {
         super.setUp();
+
         ManagerOptions options = new ManagerOptions();
         options.setEnableStorageEncryption(true);
-        cryptoManager = new Manager(getTestContext(TEST_DIR, true), options);
+        cryptoManager = new Manager(getTestContext(TEST_ENC_DIR, true), options);
+
+        options = new ManagerOptions();
+        options.setEnableStorageEncryption(false);
+        nonCryptoManager = new Manager(getTestContext(TEST_NONENC_DIR, true),
+                Manager.DEFAULT_OPTIONS);
     }
 
     @Override
@@ -49,6 +57,8 @@ public class DatabaseEncryptionTest extends LiteTestCaseWithDB {
         super.tearDown();
         if (cryptoManager != null)
             cryptoManager.close();
+        if (nonCryptoManager != null)
+            nonCryptoManager.close();
     }
 
     public void testSymmetricKey() throws Exception {
@@ -111,12 +121,12 @@ public class DatabaseEncryptionTest extends LiteTestCaseWithDB {
         if (!isAndriod())
             return;
 
-        manager.registerEncryptionKey("123456", "seekrit");
+        nonCryptoManager.registerEncryptionKey("123456", "seekrit");
         Database seekrit = null;
         CouchbaseLiteException error = null;
         try {
             seekrit = null;
-            seekrit = manager.getDatabase("seekrit");
+            seekrit = nonCryptoManager.getDatabase("seekrit");
         } catch (CouchbaseLiteException e) {
             error = e;
         }

--- a/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
+++ b/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
@@ -59,6 +59,8 @@ public class LiteTestCaseWithDB extends LiteTestCase {
 
     protected boolean useForestDB = false;
 
+    protected boolean useSQLCipher = false;
+
     protected boolean isSQLiteDB(){
         String name = database.getStore().getClass().getName();
         return Manager.DEFAULT_STORE_CLASSNAME.equals(name);
@@ -79,6 +81,11 @@ public class LiteTestCaseWithDB extends LiteTestCase {
         // Run Unit Test with ForestDBStore
         useForestDB = true;
         super.runBare();
+
+        if (sqlcipherStorageEngineTestsEnabled()) {
+            useSQLCipher = true;
+            super.runBare();
+        }
 
         long end = System.currentTimeMillis();
         String name = getName();
@@ -118,6 +125,10 @@ public class LiteTestCaseWithDB extends LiteTestCase {
         return Boolean.parseBoolean(System.getProperty("syncgatewayTestsEnabled"));
     }
 
+    protected static boolean sqlcipherStorageEngineTestsEnabled() {
+        return Boolean.parseBoolean(System.getProperty("sqlcipherStorageEngineTestsEnabled"));
+    }
+
     protected InputStream getAsset(String name) {
         return this.getClass().getResourceAsStream("/assets/" + name);
     }
@@ -150,14 +161,15 @@ public class LiteTestCaseWithDB extends LiteTestCase {
         Manager.enableLogging(Log.TAG_REMOTE_REQUEST, Log.VERBOSE);
         Manager.enableLogging(Log.TAG_ROUTER, Log.VERBOSE);
 
-        // forestdb
-        if(useForestDB) {
+        if(useForestDB) { // forestdb
             ManagerOptions options = new ManagerOptions();
             options.setStoreClassName("com.couchbase.lite.store.ForestDBStore");
             manager = new Manager(context, options);
-        }
-        // SQLite
-        else{
+        } else if (useSQLCipher) { // SQLCipher
+            ManagerOptions options = Manager.DEFAULT_OPTIONS;
+            options.setEnableStorageEncryption(true);
+            manager = new Manager(context, options);
+        } else { // SQLite
             manager = new Manager(context, Manager.DEFAULT_OPTIONS);
         }
     }


### PR DESCRIPTION
Added sqlcipherStorageEngineTestsEnabled property to test.properties to determine whether the storage engine tests are enabled.