### PR TITLE
From profiling tool, I see `QueryRow.getDocument()` loads body of doc…

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/performance/Test15_AllDocsQuery.java
+++ b/src/androidTest/java/com/couchbase/lite/performance/Test15_AllDocsQuery.java
@@ -77,7 +77,8 @@ public class Test15_AllDocsQuery extends PerformanceTestCase {
         QueryEnumerator rowEnum = query.run();
         while (rowEnum.hasNext()) {
             QueryRow row = rowEnum.next();
-            assertNotNull(row.getDocument());
+            assertNotNull(row.getDocumentId());
+            assertNotNull(row.getDocumentRevisionId());
         }
         long end = System.currentTimeMillis();
         logPerformanceStats((end - start), getNumberOfDocuments() + ", " + getSizeOfDocument());


### PR DESCRIPTION
…ument. However, AllDocsQuery without include_docs=true does not load body. So update Test15 performance test case to avoid loading document body.