### PR TITLE
Fixed Java Core 894 - Replication.docIds API discrepancy

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationTest.java
@@ -136,7 +136,6 @@ public class ReplicationTest extends LiteTestCaseWithDB {
         assertEquals(fakeRemoteURL, r2.getRemoteUrl());
         assertTrue(r2.isPull());
 
-
         Replication r3 = database.createPullReplication(fakeRemoteURL);
         assertNotNull(r3);
         assertTrue(r3 != r2);


### PR DESCRIPTION
- ported unit test from couchbase/couchbase-lite-ios@551ce20