### PR TITLE
Fixed couchbase-lite-android issue 773 - NPE when call getUserAgent f…

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ManagerTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ManagerTest.java
@@ -607,7 +607,7 @@ public class ManagerTest extends LiteTestCaseWithDB {
     }
 
     public void testGetUserAgent() {
-        String userAgent = manager.getUserAgent();
+        String userAgent = Manager.getUserAgent();
         assertTrue(userAgent.indexOf(Manager.PRODUCT_NAME + "/" + Version.SYNC_PROTOCOL_VERSION) != -1);
     }
 }

--- a/src/androidTest/java/com/couchbase/lite/replicator/ChangeTrackerTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ChangeTrackerTest.java
@@ -50,10 +50,6 @@ public class ChangeTrackerTest extends LiteTestCaseWithDB {
         URL testURL = getReplicationURL();
 
         ChangeTrackerClient client = new ChangeTrackerClient() {
-            @Override
-            public String getUserAgent() {
-                return manager.getUserAgent();
-            }
 
             @Override
             public void changeTrackerStopped(ChangeTracker tracker) {
@@ -223,11 +219,6 @@ public class ChangeTrackerTest extends LiteTestCaseWithDB {
 
         ChangeTrackerClient client = new ChangeTrackerClient() {
             @Override
-            public String getUserAgent() {
-                return manager.getUserAgent();
-            }
-
-            @Override
             public void changeTrackerStopped(ChangeTracker tracker) {
                 changeTrackerFinishedSignal.countDown();
             }
@@ -301,11 +292,6 @@ public class ChangeTrackerTest extends LiteTestCaseWithDB {
         final CountDownLatch changeTrackerFinishedSignal = new CountDownLatch(1);
 
         ChangeTrackerClient client = new ChangeTrackerClient() {
-            @Override
-            public String getUserAgent() {
-                return manager.getUserAgent();
-            }
-
             @Override
             public void changeTrackerStopped(ChangeTracker tracker) {
                 Log.v(TAG, "changeTrackerStopped");
@@ -383,11 +369,6 @@ public class ChangeTrackerTest extends LiteTestCaseWithDB {
         URL testURL = getReplicationURL();
 
         ChangeTrackerClient client = new ChangeTrackerClient() {
-            @Override
-            public String getUserAgent() {
-                return manager.getUserAgent();
-            }
-
             @Override
             public void changeTrackerStopped(ChangeTracker tracker) {
                 changeTrackerFinishedSignal.countDown();


### PR DESCRIPTION
…rom ChangeTracker.

- Actual problem is ChangeTracker is running when PullReplicator becomes STOPPED state. But this is race condition, then hard to identify the root issue now.
- Instead, Change Manager.getUserAgent to static method, and give up platform specific information.