### PR TITLE
Fixed #784 - Emitting null with the ForestDB engine causes segfault

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ViewsTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ViewsTest.java
@@ -3231,4 +3231,38 @@ public class ViewsTest extends LiteTestCaseWithDB {
         Log.e(TAG, "Descending query: rows.getCount() = " + rows.getCount());
         assertEquals(0, rows.getCount());
     }
+
+    //
+    public void testEmitWithNullKey() throws Exception {
+        // set up view
+        View view = database.getView("vu");
+        assertNotNull(view);
+        view.setMap(new Mapper() {
+            @Override
+            public void map(Map<String, Object> document, Emitter emitter) {
+                // null key -> ignored
+                emitter.emit(null, null);
+            }
+        }, "1");
+        assertNotNull(view.getMap());
+        assertEquals(0, view.getCurrentTotalRows());
+
+        // insert 1 doc
+        Map<String, Object> dict = new HashMap<String, Object>();
+        dict.put("_id", "11111");
+        assertNotNull(putDoc(database, dict));
+
+        // regular query
+        Query query = view.createQuery();
+        assertNotNull(query);
+        QueryEnumerator e = query.run();
+        assertNotNull(e);
+        assertEquals(0, e.getCount());
+
+        // query with null key. it should be ignored. this caused exception previously for sqlite
+        query.setKeys(Collections.singletonList(null));
+        e = query.run();
+        assertNotNull(e);
+        assertEquals(0, e.getCount());
+    }
 }

--- a/src/androidTest/java/com/couchbase/lite/ViewsTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ViewsTest.java
@@ -3232,7 +3232,7 @@ public class ViewsTest extends LiteTestCaseWithDB {
         assertEquals(0, rows.getCount());
     }
 
-    //
+    // - (void) test28_Nil_Key
     public void testEmitWithNullKey() throws Exception {
         // set up view
         View view = database.getView("vu");
@@ -3241,7 +3241,8 @@ public class ViewsTest extends LiteTestCaseWithDB {
             @Override
             public void map(Map<String, Object> document, Emitter emitter) {
                 // null key -> ignored
-                emitter.emit(null, null);
+                emitter.emit(null,  "foo");
+                emitter.emit("name", "bar");
             }
         }, "1");
         assertNotNull(view.getMap());
@@ -3257,7 +3258,11 @@ public class ViewsTest extends LiteTestCaseWithDB {
         assertNotNull(query);
         QueryEnumerator e = query.run();
         assertNotNull(e);
-        assertEquals(0, e.getCount());
+        assertEquals(1, e.getCount());
+        QueryRow row = e.getRow(0);
+        assertNotNull(row);
+        assertEquals("name", row.getKey());
+        assertEquals("bar", row.getValue());
 
         // query with null key. it should be ignored. this caused exception previously for sqlite
         query.setKeys(Collections.singletonList(null));


### PR DESCRIPTION
- Fixes are in java-core and java-forestdb. null key should be ignored.
- This commit is to add unit test for it.