### PR TITLE
Fixed java-core 1163 - Replicator sends duplicated Replicator state.

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -191,7 +191,7 @@ public class DatabaseTest extends LiteTestCaseWithDB {
             assertEquals(0, database.getActiveReplications().size());
 
             final CountDownLatch replicationRunning = new CountDownLatch(1);
-            replication.addChangeListener(new ReplicationActiveObserver(replicationRunning));
+            replication.addChangeListener(new ReplicationRunningObserver(replicationRunning));
 
             replication.start();
 

--- a/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
+++ b/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
@@ -7,6 +7,7 @@ import com.couchbase.lite.mockserver.MockDocumentGet;
 import com.couchbase.lite.mockserver.MockHelper;
 import com.couchbase.lite.replicator.CustomizableMockHttpClient;
 import com.couchbase.lite.replicator.Replication;
+import com.couchbase.lite.replicator.ReplicationState;
 import com.couchbase.lite.router.Router;
 import com.couchbase.lite.router.RouterCallbackBlock;
 import com.couchbase.lite.router.URLConnection;
@@ -824,18 +825,16 @@ public class LiteTestCaseWithDB extends LiteTestCase {
     }
 
     public static class ReplicationIdleObserver implements Replication.ChangeListener {
+        private CountDownLatch idleSignal;
 
-        private CountDownLatch doneSignal;
-
-        public ReplicationIdleObserver(CountDownLatch doneSignal) {
-            this.doneSignal = doneSignal;
+        public ReplicationIdleObserver(CountDownLatch idleSignal) {
+            this.idleSignal = idleSignal;
         }
 
         @Override
         public void changed(Replication.ChangeEvent event) {
-
-            if (event.getSource().getStatus() == Replication.ReplicationStatus.REPLICATION_IDLE) {
-                doneSignal.countDown();
+            if (event.getTransition().getDestination() == ReplicationState.IDLE) {
+                idleSignal.countDown();
             }
         }
     }
@@ -849,7 +848,7 @@ public class LiteTestCaseWithDB extends LiteTestCase {
 
         @Override
         public void changed(Replication.ChangeEvent event) {
-            if (event.getSource().getStatus() == Replication.ReplicationStatus.REPLICATION_STOPPED) {
+            if (event.getTransition().getDestination() == ReplicationState.STOPPED) {
                 doneSignal.countDown();
                 assertEquals(event.getChangeCount(), event.getCompletedChangeCount());
             }
@@ -857,35 +856,31 @@ public class LiteTestCaseWithDB extends LiteTestCase {
     }
 
     public static class ReplicationOfflineObserver implements Replication.ChangeListener {
+        private CountDownLatch offlineSignal;
 
-        private CountDownLatch doneSignal;
-
-        public ReplicationOfflineObserver(CountDownLatch doneSignal) {
-            this.doneSignal = doneSignal;
+        public ReplicationOfflineObserver(CountDownLatch offlineSignal) {
+            this.offlineSignal = offlineSignal;
         }
 
         @Override
         public void changed(Replication.ChangeEvent event) {
-
-            if (event.getSource().getStatus() == Replication.ReplicationStatus.REPLICATION_OFFLINE) {
-                doneSignal.countDown();
+            if (event.getTransition().getDestination() == ReplicationState.OFFLINE) {
+                offlineSignal.countDown();
             }
         }
     }
 
-    public static class ReplicationActiveObserver implements Replication.ChangeListener {
+    public static class ReplicationRunningObserver implements Replication.ChangeListener {
+        private CountDownLatch runningSignal;
 
-        private CountDownLatch doneSignal;
-
-        public ReplicationActiveObserver(CountDownLatch doneSignal) {
-            this.doneSignal = doneSignal;
+        public ReplicationRunningObserver(CountDownLatch runningSignal) {
+            this.runningSignal = runningSignal;
         }
 
         @Override
         public void changed(Replication.ChangeEvent event) {
-
-            if (event.getSource().getStatus() == Replication.ReplicationStatus.REPLICATION_ACTIVE) {
-                doneSignal.countDown();
+            if (event.getTransition().getDestination() == ReplicationState.RUNNING) {
+                runningSignal.countDown();
             }
         }
     }

--- a/src/androidTest/java/com/couchbase/lite/performance/PerformanceTestCase.java
+++ b/src/androidTest/java/com/couchbase/lite/performance/PerformanceTestCase.java
@@ -21,8 +21,9 @@ import com.couchbase.lite.Database;
 import com.couchbase.lite.LiteTestCase;
 import com.couchbase.lite.Manager;
 import com.couchbase.lite.ManagerOptions;
-import com.couchbase.lite.storage.SQLiteNativeLibrary;
 import com.couchbase.lite.replicator.Replication;
+import com.couchbase.lite.replicator.ReplicationState;
+import com.couchbase.lite.storage.SQLiteNativeLibrary;
 import com.couchbase.lite.support.FileDirUtils;
 import com.couchbase.lite.util.Log;
 import com.couchbase.lite.util.Utils;
@@ -205,7 +206,7 @@ public class PerformanceTestCase extends LiteTestCase {
 
         @Override
         public void changed(Replication.ChangeEvent event) {
-            if (event.getSource().getStatus() == Replication.ReplicationStatus.REPLICATION_STOPPED) {
+            if (event.getTransition().getDestination() == ReplicationState.STOPPED) {
                 doneSignal.countDown();
                 assertEquals(event.getChangeCount(), event.getCompletedChangeCount());
             }


### PR DESCRIPTION
Reason duplicated replicator states are notified by `changed()` is because most of unit tests check replicator state which could be already changed to next state. So the replicator enters STOPPING state, then ChangeEvent is fired, next the replicator enters STOPPED state, then ChangeEvent is fired again. When listener receives notification for STOPPING, the replicator state already changed to STOPPED state. So it seems like STOPPED state are fired twice. But actually STOPPING state and STOPPED states are fired. Instead of checking Replicator.status, needs to check transition destination.