### PR TITLE
Unit test for GET /{db}/{docID}?attachments =true

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/RouterTest.java
+++ b/src/androidTest/java/com/couchbase/lite/RouterTest.java
@@ -178,6 +178,25 @@ public class RouterTest extends LiteTestCaseWithDB {
         is.close();
         assertEquals(406, body.get("status"));
         assertEquals("not_acceptable", body.get("error"));
+
+        // with attachments=true query parameter
+        result = (Map<String, Object>)send("GET", "/db/docWithAttachment?attachments=true", Status.OK, null);
+        assertNotNull(result);
+        assertNotNull(result.get("_attachments"));
+        Map<String, Object> att = (Map<String, Object>) ((Map<String, Object>) result.get("_attachments")).get("inline.txt");
+        assertNotNull(att);
+        assertNotNull(att.get("data"));
+        assertTrue(((String)att.get("data")).length() > 0);
+        assertFalse(att.containsKey("stub"));
+
+        // without attachments=true query parameter
+        result = (Map<String, Object>)send("GET", "/db/docWithAttachment", Status.OK, null);
+        assertNotNull(result);
+        assertNotNull(result.get("_attachments"));
+        att = (Map<String, Object>) ((Map<String, Object>) result.get("_attachments")).get("inline.txt");
+        assertNotNull(att);
+        assertNotNull(att.get("stub"));
+        assertFalse(att.containsKey("data"));
     }
 
     private Map<String, Object> valueMapWithRev(String revId) {


### PR DESCRIPTION
- With attachments=true query parameter, response json should include data.