### PR TITLE
Fixed Java Core Issue 840 - SQLiteStore not support auto compact

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -125,6 +125,25 @@ public class DatabaseTest extends LiteTestCaseWithDB {
         }
     }
 
+    /**
+     * in DatabaseInternal_Tests.m
+     * - (void) test28_enableAutoCompact
+     */
+    public void test28_enableAutoCompact() throws CouchbaseLiteException {
+        // Ensure that a database created without auto-compact (by CBL 1.1, or prior to 10/5/15) can
+        // still be opened, since it has to be switched to auto-compact mode.
+        Database.setAutoCompact(false);
+        Database manualDB = manager.getDatabase("manualcompact");
+        assertNotNull(manualDB);
+        this.createDocWithProperties(new HashMap<String, Object>(), manualDB);
+        manualDB.close();
+
+        Database.setAutoCompact(true);
+        manualDB = manager.getDatabase("manualcompact");
+        assertNotNull(manualDB);
+        manualDB.close();
+    }
+
     public void testPruneRevsToMaxDepthViaCompact() throws Exception {
 
         Map<String, Object> properties = new HashMap<String, Object>();

--- a/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
+++ b/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
@@ -724,14 +724,19 @@ public class LiteTestCaseWithDB extends LiteTestCase {
         }
     }
 
-    protected Document createDocWithProperties(Map<String, Object> properties1)
+    protected Document createDocWithProperties(Map<String, Object> props)
             throws CouchbaseLiteException {
-        Document doc1 = database.createDocument();
-        UnsavedRevision revUnsaved = doc1.createRevision();
-        revUnsaved.setUserProperties(properties1);
+        return createDocWithProperties(props, database);
+    }
+
+    protected Document createDocWithProperties(Map<String, Object> props, Database db)
+            throws CouchbaseLiteException {
+        Document doc = db.createDocument();
+        UnsavedRevision revUnsaved = doc.createRevision();
+        revUnsaved.setUserProperties(props);
         SavedRevision rev = revUnsaved.save();
         assertNotNull(rev);
-        return doc1;
+        return doc;
     }
 
     protected HttpClientFactory mockFactoryFactory(final CustomizableMockHttpClient mockHttpClient) {


### PR DESCRIPTION
- iOS does not support autoCompact for SQLiteStore
- Implemented autoCompact for ForestDB. Current implementation was not sufficient.
- Add interface to enable/disable autoCompact