### PR TITLE
Fixed #920 - Keep BasicAuthenticator for backward compatibility

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/auth/AuthTest.java
+++ b/src/androidTest/java/com/couchbase/lite/auth/AuthTest.java
@@ -91,5 +91,9 @@ public class AuthTest extends LiteTestCase {
         String password = "password";
         PasswordAuthorizer basicAuth = new PasswordAuthorizer(username, password);
         Assert.assertEquals(username + ":" + password, basicAuth.authUserInfo());
+
+        // test deprecated class
+        basicAuth = new BasicAuthenticator(username, password);
+        assertEquals(username + ":" + password, basicAuth.authUserInfo());
     }
 }

--- a/src/androidTest/java/com/couchbase/lite/replicator/ReplicationMockWebServerTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ReplicationMockWebServerTest.java
@@ -38,7 +38,6 @@ import com.couchbase.lite.View;
 import com.couchbase.lite.auth.Authenticator;
 import com.couchbase.lite.auth.AuthenticatorFactory;
 import com.couchbase.lite.auth.FacebookAuthorizer;
-import com.couchbase.lite.auth.PasswordAuthorizer;
 import com.couchbase.lite.internal.RevisionInternal;
 import com.couchbase.lite.mockserver.MockBulkDocs;
 import com.couchbase.lite.mockserver.MockChangesFeed;
@@ -4056,7 +4055,7 @@ public class ReplicationMockWebServerTest extends LiteTestCaseWithDB {
             pusher.setDocIds(Arrays.asList(doc1.getId()));
 
             // custom authenticator
-            PasswordAuthorizer authenticator = new PasswordAuthorizer("foo", "bar");
+            Authenticator authenticator = AuthenticatorFactory.createBasicAuthenticator("foo", "bar");
             pusher.setAuthenticator(authenticator);
 
             // custom request headers


### PR DESCRIPTION
- some users directly create BasicAuthenticator instance instead of using AuthenticatorFactory. We need to keep this for a while.