### PR TITLE
Fixed #942 - Pull replicator filter not working in 1.3.0-27 against C…

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/replicator/ChangeTrackerTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/ChangeTrackerTest.java
@@ -191,7 +191,7 @@ public class ChangeTrackerTest extends LiteTestCaseWithDB {
                 changeTracker.getChangesFeedPath());
 
         changeTracker.setUsePOST(true);
-        assertEquals("_changes?feed=longpoll&heartbeat=30000&since=0&limit=50",
+        assertEquals("_changes?feed=longpoll&heartbeat=30000&since=0&limit=50&filter=filter",
                 changeTracker.getChangesFeedPath());
         Map<String, Object> body = changeTracker.changesFeedPOSTBodyMap();
         assertTrue(body.containsKey("filter"));
@@ -220,7 +220,7 @@ public class ChangeTrackerTest extends LiteTestCaseWithDB {
         assertEquals(expectedFeedPath, changesFeedPath);
 
         changeTracker.setUsePOST(true);
-        assertEquals("_changes?feed=longpoll&heartbeat=30000&since=0&limit=50",
+        assertEquals("_changes?feed=longpoll&heartbeat=30000&since=0&limit=50&filter=_doc_ids",
                 changeTracker.getChangesFeedPath());
         Map<String, Object> postBodyMap = changeTracker.changesFeedPOSTBodyMap();
         assertEquals("_doc_ids", postBodyMap.get("filter"));


### PR DESCRIPTION
…ouchDB

- CBL switched to use `POST` protocol from `GET` for `/_changes` REST API. CouchDB does not support `filter` parameter in the body of POST request. It should be in query parameter.