### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-java-core/issues/1352

### DIFF
--- a/src/main/java/com/couchbase/lite/android/AndroidSQLiteStorageEngine.java
+++ b/src/main/java/com/couchbase/lite/android/AndroidSQLiteStorageEngine.java
@@ -15,6 +15,7 @@
  */
 package com.couchbase.lite.android;
 
+import android.os.Build;
 import android.os.Looper;
 
 import com.couchbase.lite.internal.database.DatabasePlatformSupport;
@@ -45,5 +46,15 @@ public class AndroidSQLiteStorageEngine extends SQLiteStorageEngineBase {
     @Override
     protected String getICUDatabasePath() {
         return ICUUtils.getICUDatabasePath(context);
+    }
+
+    @Override
+    protected int getWALConnectionPoolSize() {
+        // Crash when running with SQLCipher
+        // https://github.com/couchbase/couchbase-lite-java-core/issues/1352
+        // We observed SQLCipher crashes with multiple connections on Android API 19 (x86).
+        // Android 5.x (LOLLIPOP/API21) or higher uses multiple connections.
+        // Android 4.x (API 20) or lower uses single connection mode.
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP ? 1 : 4;
     }
 }


### PR DESCRIPTION
Crash when running with SQLCipher

- Multiple SQLite connections with SQLCipher could cause crashes in the native codes.
- We decided to use single connection with Android API version 20 or lower, And use multiple connections with API 21 or higher.