### PR TITLE
Fixed #967 - query.setSkip() skip too much with forestdb 1.3.0

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ViewsTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ViewsTest.java
@@ -3674,14 +3674,13 @@ public class ViewsTest extends LiteTestCaseWithDB {
         Query query = database.createAllDocumentsQuery();
         query.setPrefetch(true);
         query.setSkip(2);
-        query.setLimit(3);
         QueryEnumerator result = query.run();
-        CountDown countDown = new CountDown(3); // limit is 3
+        CountDown countDown = new CountDown(4);
         Log.i(TAG, "start");
         while (result.hasNext()) {
             String docID = result.next().getDocumentId();
             Log.i(TAG, "docID=" + docID);
-            assertTrue(docID.compareTo("258") >= 0 && docID.compareTo("456") <= 0); // 258, 369, and 456
+            assertTrue(docID.compareTo("258") >= 0); // 258, 369, 456, and 789
             countDown.countDown();
         }
         Log.i(TAG, "stop");

--- a/src/androidTest/java/com/couchbase/lite/ViewsTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ViewsTest.java
@@ -21,6 +21,7 @@ import com.couchbase.lite.View.TDViewCollation;
 import com.couchbase.lite.internal.RevisionInternal;
 import com.couchbase.lite.store.Store;
 import com.couchbase.lite.store.StoreDelegate;
+import com.couchbase.lite.util.CountDown;
 import com.couchbase.lite.util.Log;
 
 import junit.framework.Assert;
@@ -3658,5 +3659,32 @@ public class ViewsTest extends LiteTestCaseWithDB {
             i++;
         }
         assertEquals(expected.length, i);
+    }
+
+    // https://github.com/couchbase/couchbase-lite-android/issues/967
+    public void testSetSkip() throws CouchbaseLiteException {
+        Map<String, Object> props = new HashMap<String, Object>();
+        props.put("data", "ok");
+        database.getDocument("123").putProperties(props);
+        database.getDocument("147").putProperties(props);
+        database.getDocument("258").putProperties(props);
+        database.getDocument("369").putProperties(props);
+        database.getDocument("456").putProperties(props);
+        database.getDocument("789").putProperties(props);
+        Query query = database.createAllDocumentsQuery();
+        query.setPrefetch(true);
+        query.setSkip(2);
+        query.setLimit(3);
+        QueryEnumerator result = query.run();
+        CountDown countDown = new CountDown(3); // limit is 3
+        Log.i(TAG, "start");
+        while (result.hasNext()) {
+            String docID = result.next().getDocumentId();
+            Log.i(TAG, "docID=" + docID);
+            assertTrue(docID.compareTo("258") >= 0 && docID.compareTo("456") <= 0); // 258, 369, and 456
+            countDown.countDown();
+        }
+        Log.i(TAG, "stop");
+        assertEquals(0, countDown.getCount());
     }
 }


### PR DESCRIPTION
This PR is unit test for #967