### PR TITLE
Fixed https://github.com/couchbase/couchbase-lite-java-core/issues/1441

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
+++ b/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
@@ -199,7 +199,7 @@ public class LiteTestCaseWithDB extends LiteTestCase {
             // NOTE: retry and sleep is only for Windows. Other platforms never fail.
             int counter = 0;
             while (!FileDirUtils.cleanDirectory(context.getFilesDir()) && counter < 10) {
-                // NOTE: forestdb releses resources in Object.destroy()
+                // NOTE: forestdb releses resources in Object.finalize()
                 System.gc();
                 try {
                     Thread.sleep(1000);
@@ -259,7 +259,9 @@ public class LiteTestCaseWithDB extends LiteTestCase {
 
     protected void stopDatabase() {
         if (database != null) {
-            database.close();
+            if(!database.close()){
+                Log.e(TAG, "Error in database.close()");
+            }
         }
     }
 

--- a/src/androidTest/java/com/couchbase/lite/ViewsTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ViewsTest.java
@@ -3686,4 +3686,55 @@ public class ViewsTest extends LiteTestCaseWithDB {
         Log.i(TAG, "stop");
         assertEquals(0, countDown.getCount());
     }
+
+    public void testSetLimit() throws CouchbaseLiteException {
+        Map<String, Object> props = new HashMap<String, Object>();
+        props.put("data", "ok");
+        database.getDocument("123").putProperties(props);
+        database.getDocument("147").putProperties(props);
+        database.getDocument("258").putProperties(props);
+        database.getDocument("369").putProperties(props);
+        database.getDocument("456").putProperties(props);
+        database.getDocument("789").putProperties(props);
+        Query query = database.createAllDocumentsQuery();
+        query.setPrefetch(true);
+        query.setLimit(3);
+        QueryEnumerator result = query.run();
+        CountDown countDown = new CountDown(3); // limit is 3
+        Log.i(TAG, "start");
+        while (result.hasNext()) {
+            String docID = result.next().getDocumentId();
+            Log.i(TAG, "docID=" + docID);
+            assertTrue(docID.compareTo("258") <= 0);
+            countDown.countDown();
+        }
+        Log.i(TAG, "stop");
+        assertEquals(0, countDown.getCount());
+    }
+
+    public void testSetSkipAndLimit() throws CouchbaseLiteException {
+        Map<String, Object> props = new HashMap<String, Object>();
+        props.put("data", "ok");
+        database.getDocument("123").putProperties(props);
+        database.getDocument("147").putProperties(props);
+        database.getDocument("258").putProperties(props);
+        database.getDocument("369").putProperties(props);
+        database.getDocument("456").putProperties(props);
+        database.getDocument("789").putProperties(props);
+        Query query = database.createAllDocumentsQuery();
+        query.setPrefetch(true);
+        query.setSkip(2);
+        query.setLimit(3);
+        QueryEnumerator result = query.run();
+        CountDown countDown = new CountDown(3); // limit is 3
+        Log.i(TAG, "start");
+        while (result.hasNext()) {
+            String docID = result.next().getDocumentId();
+            Log.i(TAG, "docID=" + docID);
+            assertTrue(docID.compareTo("258") >= 0 && docID.compareTo("456") <= 0);
+            countDown.countDown();
+        }
+        Log.i(TAG, "stop");
+        assertEquals(0, countDown.getCount());
+    }
 }


### PR DESCRIPTION
Title: ForestDB: Query.setLimit() could cause crashes.

This is unit test for https://github.com/couchbase/couchbase-lite-java-core/issues/1441