### PR TITLE
Fixed Java Core Issue 1492 - Test failure RemoteRequestTest.failingTe…

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/mockserver/MockDispatcher.java
+++ b/src/androidTest/java/com/couchbase/lite/mockserver/MockDispatcher.java
@@ -90,6 +90,12 @@ public class MockDispatcher extends Dispatcher {
 
     Object lockResponseQueue = new Object();
 
+    private boolean isResponseQueueEmpty(BlockingQueue queue) {
+        synchronized (lockResponseQueue) {
+            return queue.isEmpty();
+        }
+    }
+
     @Override
     public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
         for (String pathRegex : queueMap.keySet()) {
@@ -100,7 +106,7 @@ public class MockDispatcher extends Dispatcher {
                     String msg = String.format(Locale.ENGLISH, "No queue found for pathRegex: %s", pathRegex);
                     throw new RuntimeException(msg);
                 }
-                if (!responseQueue.isEmpty()) {
+                if (!isResponseQueueEmpty(responseQueue)) {
                     SmartMockResponse smartMockResponse = null;
                     synchronized (lockResponseQueue) {
                         smartMockResponse = responseQueue.take(); // as checked isEmpty() before, chance of blocking is low....

--- a/src/androidTest/java/com/couchbase/lite/replicator/RemoteRequestTest.java
+++ b/src/androidTest/java/com/couchbase/lite/replicator/RemoteRequestTest.java
@@ -232,7 +232,7 @@ public class RemoteRequestTest extends LiteTestCaseWithDB {
      * Reproduce a severe issue where the pusher stops working because it's remoteRequestExecutor
      * is full of tasks which are all blocked trying to add more tasks to the queue.
      */
-    public void failingTestRetryQueueDeadlock() throws Exception {
+    public void testRetryQueueDeadlock() throws Exception {
         // lower retry to speed up test
         com.couchbase.lite.replicator.RemoteRequestRetry.RETRY_DELAY_MS = 5;
 


### PR DESCRIPTION
…stRetryQueueDeadlock on Jenkins

- responseQueue instance was not thread-safe with existing codes.