### PR TITLE
Fixed Java Core Issue 1493 - test failure ViewsTest.failingTestAllDoc…

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/ViewsTest.java
+++ b/src/androidTest/java/com/couchbase/lite/ViewsTest.java
@@ -906,7 +906,7 @@ public class ViewsTest extends LiteTestCaseWithDB {
     /**
      * NOTE: ChangeNotification should not be fired for 0 match query.
      */
-    public void failingTestAllDocumentsLiveQuery() throws CouchbaseLiteException {
+    public void testAllDocumentsLiveQuery() throws CouchbaseLiteException {
         final AtomicInteger changeCount = new AtomicInteger();
 
         Database db = startDatabase();
@@ -941,8 +941,8 @@ public class ViewsTest extends LiteTestCaseWithDB {
 
         db.getDocument("1").createRevision().save();
 
-        // The query must update before sending notifications
-        assertEquals(1, changeCount.get());
+        // NOTE: checking changeCount value this timing is inaccurate because of multi-threadings.
+
         query.waitForRows();
         assertEquals(2, changeCount.get());
 


### PR DESCRIPTION
…umentsLiveQuery on Jenkins

- LiveQuery uses multi-threading checking changeCount just after save document is not correct way to test.