### PR TITLE
2.0 API updates and bug fixes

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
@@ -8,7 +8,7 @@ import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.List;
 import java.util.Map;
 
@@ -156,16 +156,16 @@ public class ArrayTest extends BaseTest {
                 assertEquals(true, a.getObject(0));
                 assertEquals(false, a.getObject(1));
                 assertEquals("string", a.getObject(2));
-                assertEquals(0, a.getObject(3));
-                assertEquals(1, a.getObject(4));
-                assertEquals(-1, a.getObject(5));
+                assertEquals(0, ((Number)a.getObject(3)).intValue());
+                assertEquals(1, ((Number)a.getObject(4)).intValue());
+                assertEquals(-1, ((Number)a.getObject(5)).intValue());
                 assertEquals(1.1, a.getObject(6));
                 assertEquals(kArrayTestDate, a.getObject(7));
                 assertEquals(null, a.getObject(8));
 
                 // dictionary
                 Dictionary subdict = (Dictionary) a.getObject(9);
-                Map<String, Object> expectedMap = new HashMap<>();
+                Map<String, Object> expectedMap = new TreeMap<>();
                 expectedMap.put("name", "Scott Tiger");
                 assertEquals(expectedMap, subdict.toMap());
 
@@ -212,16 +212,16 @@ public class ArrayTest extends BaseTest {
                 assertEquals(true, a.getObject(12 + 0));
                 assertEquals(false, a.getObject(12 + 1));
                 assertEquals("string", a.getObject(12 + 2));
-                assertEquals(0, a.getObject(12 + 3));
-                assertEquals(1, a.getObject(12 + 4));
-                assertEquals(-1, a.getObject(12 + 5));
+                assertEquals(0, ((Number)a.getObject(12 + 3)).intValue());
+                assertEquals(1, ((Number)a.getObject(12 + 4)).intValue());
+                assertEquals(-1, ((Number)a.getObject(12 + 5)).intValue());
                 assertEquals(1.1, a.getObject(12 + 6));
                 assertEquals(kArrayTestDate, a.getObject(12 + 7));
                 assertEquals(null, a.getObject(12 + 8));
 
                 // dictionary
                 Dictionary subdict = (Dictionary) a.getObject(12 + 9);
-                Map<String, Object> expectedMap = new HashMap<>();
+                Map<String, Object> expectedMap = new TreeMap<>();
                 expectedMap.put("name", "Scott Tiger");
                 assertEquals(expectedMap, subdict.toMap());
 
@@ -263,16 +263,16 @@ public class ArrayTest extends BaseTest {
                 assertEquals(true, a.getObject(0));
                 assertEquals(false, a.getObject(1));
                 assertEquals("string", a.getObject(2));
-                assertEquals(0, a.getObject(3));
-                assertEquals(1, a.getObject(4));
-                assertEquals(-1, a.getObject(5));
+                assertEquals(0, ((Number)a.getObject(3)).intValue());
+                assertEquals(1, ((Number)a.getObject(4)).intValue());
+                assertEquals(-1, ((Number)a.getObject(5)).intValue());
                 assertEquals(1.1, a.getObject(6));
                 assertEquals(kArrayTestDate, a.getObject(7));
                 assertEquals(null, a.getObject(8));
 
                 // dictionary
                 Dictionary subdict = (Dictionary) a.getObject(9);
-                Map<String, Object> expectedMap = new HashMap<>();
+                Map<String, Object> expectedMap = new TreeMap<>();
                 expectedMap.put("name", "Scott Tiger");
                 assertEquals(expectedMap, subdict.toMap());
 
@@ -523,9 +523,9 @@ public class ArrayTest extends BaseTest {
                 assertNull(a.getNumber(0));
                 assertNull(a.getNumber(1));
                 assertNull(a.getNumber(2));
-                assertEquals(0, a.getNumber(3));
-                assertEquals(1, a.getNumber(4));
-                assertEquals(-1, a.getNumber(5));
+                assertEquals(0, ((Number)a.getNumber(3)).intValue());
+                assertEquals(1, ((Number)a.getNumber(4)).intValue());
+                assertEquals(-1, ((Number)a.getNumber(5)).intValue());
                 assertEquals(1.1, a.getNumber(6));
                 assertNull(a.getNumber(7));
                 assertNull(a.getNumber(8));
@@ -656,20 +656,19 @@ public class ArrayTest extends BaseTest {
         save(doc, "array", array, new Validator<Array>() {
             @Override
             public void validate(Array a) {
-                assertEquals(Integer.MIN_VALUE, a.getNumber(0));
-                assertEquals(Integer.MAX_VALUE, a.getNumber(1));
-                assertEquals(Integer.MIN_VALUE, a.getObject(0));
-                assertEquals(Integer.MAX_VALUE, a.getObject(1));
+                assertEquals(Integer.MIN_VALUE, a.getNumber(0).intValue());
+                assertEquals(Integer.MAX_VALUE, a.getNumber(1).intValue());
+                assertEquals(Integer.MIN_VALUE, ((Number)a.getObject(0)).intValue());
+                assertEquals(Integer.MAX_VALUE, ((Number)a.getObject(1)).intValue());
                 assertEquals(Integer.MIN_VALUE, a.getInt(0));
                 assertEquals(Integer.MAX_VALUE, a.getInt(1));
 
-                // TODO https://github.com/couchbase/couchbase-lite-android/issues/1158
-//                assertEquals(Long.MIN_VALUE, a.getNumber(2));
-//                assertEquals(Long.MAX_VALUE, a.getNumber(3));
-//                assertEquals(Long.MIN_VALUE, a.getObject(2));
-//                assertEquals(Long.MAX_VALUE, a.getObject(3));
-//                assertEquals(Long.MIN_VALUE, a.getLong(2));
-//                assertEquals(Long.MAX_VALUE, a.getLong(3));
+                assertEquals(Long.MIN_VALUE, a.getNumber(2));
+                assertEquals(Long.MAX_VALUE, a.getNumber(3));
+                assertEquals(Long.MIN_VALUE, a.getObject(2));
+                assertEquals(Long.MAX_VALUE, a.getObject(3));
+                assertEquals(Long.MIN_VALUE, a.getLong(2));
+                assertEquals(Long.MAX_VALUE, a.getLong(3));
 
                 assertEquals(Float.MIN_VALUE, a.getNumber(4));
                 assertEquals(Float.MAX_VALUE, a.getNumber(5));
@@ -812,7 +811,7 @@ public class ArrayTest extends BaseTest {
                 assertNull(a.getDictionary(6));
                 assertNull(a.getDictionary(7));
                 assertNull(a.getDictionary(8));
-                Map<String, Object> map = new HashMap<>();
+                Map<String, Object> map = new TreeMap<>();
                 map.put("name", "Scott Tiger");
                 assertEquals(map, a.getDictionary(9).toMap());
                 assertNull(a.getDictionary(10));
@@ -982,7 +981,7 @@ public class ArrayTest extends BaseTest {
                     assertNotNull(item);
                     r.add(item);
                 }
-                assertEquals(c, r);
+                assertEquals(c.toString(), r.toString());
             }
         });
     }

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
@@ -716,9 +716,8 @@ public class ArrayTest extends BaseTest {
                 assertEquals(1.49F, a.getFloat(1), 0.0F);
                 assertEquals(1.49, a.getDouble(1), 0.0);
 
-                // TODO:
-//                assertEquals(1.50, a.getObject(2));
-//                assertEquals(1.50, a.getNumber(2));
+                assertEquals(1.50, ((Number)a.getObject(2)).doubleValue(), 0.0);
+                assertEquals(1.50, a.getNumber(2).doubleValue(), 0.0);
                 assertEquals(1, a.getInt(2));
                 assertEquals(1L, a.getLong(2));
                 assertEquals(1.50F, a.getFloat(2), 0.0F);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
@@ -12,7 +12,7 @@ import java.util.ConcurrentModificationException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -168,7 +168,7 @@ public class ArrayTest extends BaseTest {
 
                 // dictionary
                 Dictionary subdict = (Dictionary) a.getObject(9);
-                Map<String, Object> expectedMap = new TreeMap<>();
+                Map<String, Object> expectedMap = new HashMap<>();
                 expectedMap.put("name", "Scott Tiger");
                 assertEquals(expectedMap, subdict.toMap());
 
@@ -224,7 +224,7 @@ public class ArrayTest extends BaseTest {
 
                 // dictionary
                 Dictionary subdict = (Dictionary) a.getObject(12 + 9);
-                Map<String, Object> expectedMap = new TreeMap<>();
+                Map<String, Object> expectedMap = new HashMap<>();
                 expectedMap.put("name", "Scott Tiger");
                 assertEquals(expectedMap, subdict.toMap());
 
@@ -275,7 +275,7 @@ public class ArrayTest extends BaseTest {
 
                 // dictionary
                 Dictionary subdict = (Dictionary) a.getObject(9);
-                Map<String, Object> expectedMap = new TreeMap<>();
+                Map<String, Object> expectedMap = new HashMap<>();
                 expectedMap.put("name", "Scott Tiger");
                 assertEquals(expectedMap, subdict.toMap());
 
@@ -814,7 +814,7 @@ public class ArrayTest extends BaseTest {
                 assertNull(a.getDictionary(6));
                 assertNull(a.getDictionary(7));
                 assertNull(a.getDictionary(8));
-                Map<String, Object> map = new TreeMap<>();
+                Map<String, Object> map = new HashMap<>();
                 map.put("name", "Scott Tiger");
                 assertEquals(map, a.getDictionary(9).toMap());
                 assertNull(a.getDictionary(10));

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
@@ -700,9 +700,10 @@ public class ArrayTest extends BaseTest {
         save(doc, "array", array, new Validator<Array>() {
             @Override
             public void validate(Array a) {
-                // TODO: https://github.com/couchbase/couchbase-lite-android/issues/1160
-//                assertEquals(1.00, a.getObject(0));
-//                assertEquals(1.00, a.getNumber(0));
+                // NOTE: Number which has no floating part is stored as Integer.
+                //       This causes type difference between before and after storing data into the database.
+                assertEquals(1.00, ((Number)a.getObject(0)).doubleValue(), 0.0);
+                assertEquals(1.00, a.getNumber(0).doubleValue(), 0.0);
                 assertEquals(1, a.getInt(0));
                 assertEquals(1L, a.getLong(0));
                 assertEquals(1.00F, a.getFloat(0), 0.0F);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseTest.java
@@ -77,7 +77,7 @@ public class BaseTest {
     protected void openDB() {
         assertNull(db);
 
-        DatabaseConfiguration options = new DatabaseConfiguration();
+        DatabaseConfiguration options = new DatabaseConfiguration(this.context);
         options.setDirectory(dir);
         db = new Database(kDatabaseName, options);
         assertNotNull(db);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConflictTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConflictTest.java
@@ -37,17 +37,16 @@ public class ConflictTest extends BaseTest {
             Document resolved = new Document();
             Set<String> changed = new HashSet<>();
 
-            // TODO: Once ReadOnlyDictionary has Iterable implementation. Change following method
-            for (String key : conflict.getBase().allKeys()) {
+            for (String key : conflict.getBase()) {
                 resolved.set(key, conflict.getBase().getObject(key));
             }
 
-            for (String key : conflict.getTheirs().allKeys()) {
+            for (String key : conflict.getTheirs()) {
                 resolved.set(key, conflict.getTheirs().getObject(key));
                 changed.add(key);
             }
 
-            for (String key : conflict.getMine().allKeys()) {
+            for (String key : conflict.getMine()) {
                 if (!changed.contains(key))
                     resolved.set(key, conflict.getMine().getObject(key));
             }

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConflictTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConflictTest.java
@@ -124,7 +124,7 @@ public class ConflictTest extends BaseTest {
     protected void openDB(ConflictResolver resolver) {
         assertNull(db);
 
-        DatabaseConfiguration options = new DatabaseConfiguration();
+        DatabaseConfiguration options = new DatabaseConfiguration(this.context);
         options.setDirectory(dir);
         options.setConflictResolver(resolver);
         db = new Database(kDatabaseName, options);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -99,7 +99,7 @@ public class DatabaseTest extends BaseTest {
         assertNotNull(doc);
         assertEquals(docID, doc.getId());
         assertFalse(doc.isDeleted());
-        assertEquals(value, doc.getObject("key"));
+        assertEquals(value, ((Number)doc.getObject("key")).intValue());
     }
 
     // helper method to purge doc and verify doc.
@@ -886,7 +886,7 @@ public class DatabaseTest extends BaseTest {
 
         // Content should be accessible & modifiable without error:
         assertEquals(docID, doc.getId());
-        assertEquals(1, doc.getObject("key"));
+        assertEquals(1, ((Number)doc.getObject("key")).intValue());
         doc.set("key", 2);
         doc.set("key1", "value");
     }
@@ -973,7 +973,7 @@ public class DatabaseTest extends BaseTest {
 
         // Content should be accessible & modifiable without error:
         assertEquals(docID, doc.getId());
-        assertEquals(1, doc.getObject("key"));
+        assertEquals(1, ((Number)doc.getObject("key")).intValue());
         doc.set("key", 2);
         doc.set("key1", "value");
     }

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -51,7 +51,7 @@ public class DatabaseTest extends BaseTest {
 
     // helper method to open database
     private Database openDatabase(String dbName) {
-        DatabaseConfiguration options = new DatabaseConfiguration();
+        DatabaseConfiguration options = new DatabaseConfiguration(this.context);
         options.setDirectory(dir);
         Database db = new Database(dbName, options);
         assertEquals(dbName, db.getName());
@@ -154,7 +154,7 @@ public class DatabaseTest extends BaseTest {
     @Test
     public void testCreateConfiguration() {
         // Default:
-        DatabaseConfiguration config1 = new DatabaseConfiguration();
+        DatabaseConfiguration config1 = new DatabaseConfiguration(this.context);
         config1.setDirectory(new File("/tmp"));
         assertNotNull(config1.getDirectory());
         assertTrue(config1.getDirectory().getAbsolutePath().length() > 0);
@@ -170,7 +170,7 @@ public class DatabaseTest extends BaseTest {
 
         // Custom
         DummyResolver resolver = new DummyResolver();
-        DatabaseConfiguration config2 = new DatabaseConfiguration();
+        DatabaseConfiguration config2 = new DatabaseConfiguration(this.context);
         config2.setDirectory(new File("/tmp/mydb"));
         config2.setConflictResolver(resolver);
         config2.setEncryptionKey("key");
@@ -187,7 +187,7 @@ public class DatabaseTest extends BaseTest {
 
     @Test
     public void testGetSetConfiguration() {
-        DatabaseConfiguration config = new DatabaseConfiguration();
+        DatabaseConfiguration config = new DatabaseConfiguration(this.context);
         config.setDirectory(this.db.getConfig().getDirectory());
 
         Database db = new Database("db", config);
@@ -204,7 +204,7 @@ public class DatabaseTest extends BaseTest {
 
     @Test
     public void testConfigurationIsCopiedWhenGetSet() {
-        DatabaseConfiguration config = new DatabaseConfiguration();
+        DatabaseConfiguration config = new DatabaseConfiguration(this.context);
         config.setDirectory(this.db.getConfig().getDirectory());
 
         Database db = new Database("db", config);
@@ -249,12 +249,7 @@ public class DatabaseTest extends BaseTest {
 
     @Test
     public void testCreateWithDefaultOption() {
-        try {
-            Database db = new Database("db", new DatabaseConfiguration());
-            fail();
-        } catch (UnsupportedOperationException e) {
-            // NOTE: CBL Android's Database constructor does not work without specified directory.
-        }
+        new Database("db", new DatabaseConfiguration(this.context));
     }
 
     @Test
@@ -288,7 +283,7 @@ public class DatabaseTest extends BaseTest {
         assertFalse(Database.exists("db", dir));
 
         // create db with custom directory
-        DatabaseConfiguration config = new DatabaseConfiguration();
+        DatabaseConfiguration config = new DatabaseConfiguration(this.context);
         config.setDirectory(dir);
         Database db = new Database("db", config);
         assertNotNull(db);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class DictionaryTest extends BaseTest {
@@ -238,6 +239,35 @@ public class DictionaryTest extends BaseTest {
         save(doc);
         doc = db.getDocument("doc1");
         assertEquals("Daniel Tiger", doc.getObject("profile"));
+    }
+
+    @Test
+    public void testRemoveDictionary(){
+        Document doc = createDocument("doc1");
+        Dictionary profile1 = new Dictionary();
+        profile1.set("name", "Scott Tiger");
+        doc.set("profile", profile1);
+        assertEquals(profile1.toMap(), doc.getDictionary("profile").toMap());
+        assertTrue(doc.contains("profile"));
+
+        // Remove profile
+        doc.remove("profile");
+        assertNull(doc.getObject("profile"));
+        assertFalse(doc.contains("profile"));
+
+        // Profile1 should be now detached:
+        profile1.set("age", 20);
+        assertEquals("Scott Tiger", profile1.getObject("name"));
+        assertEquals(20, profile1.getObject("age"));
+
+        // Check whether the profile value has no change:
+        assertNull(doc.getObject("profile"));
+
+        // Save:
+        doc = save(doc);
+
+        assertNull(doc.getObject("profile"));
+        assertFalse(doc.contains("profile"));
     }
 
     @Test

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
@@ -3,7 +3,7 @@ package com.couchbase.lite;
 import org.junit.Test;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -18,7 +18,7 @@ public class DictionaryTest extends BaseTest {
     public void testCreateDictionary() {
         Dictionary address = new Dictionary();
         assertEquals(0, address.count());
-        assertEquals(new HashMap<String, Object>(), address.toMap());
+        assertEquals(new TreeMap<String, Object>(), address.toMap());
 
         Document doc = createDocument("doc1");
         doc.set("address", address);
@@ -26,12 +26,12 @@ public class DictionaryTest extends BaseTest {
 
         save(doc);
         doc = db.getDocument("doc1");
-        assertEquals(new HashMap<String, Object>(), doc.getDictionary("address").toMap());
+        assertEquals(new TreeMap<String, Object>(), doc.getDictionary("address").toMap());
     }
 
     @Test
     public void testCreateDictionaryWithNSDictionary() {
-        Map<String, Object> dict = new HashMap<>();
+        Map<String, Object> dict = new TreeMap<>();
         dict.put("street", "1 Main street");
         dict.put("city", "Mountain View");
         dict.put("state", "CA");
@@ -66,7 +66,7 @@ public class DictionaryTest extends BaseTest {
         assertTrue(dict.getString("key") == null);
         assertTrue(dict.getDictionary("key") == null);
         assertTrue(dict.getArray("key") == null);
-        assertEquals(new HashMap<String, Object>(), dict.toMap());
+        assertEquals(new TreeMap<String, Object>(), dict.toMap());
 
         Document doc = createDocument("doc1");
         doc.set("dict", dict);
@@ -87,7 +87,7 @@ public class DictionaryTest extends BaseTest {
         assertTrue(dict.getString("key") == null);
         assertTrue(dict.getDictionary("key") == null);
         assertTrue(dict.getArray("key") == null);
-        assertEquals(new HashMap<String, Object>(), dict.toMap());
+        assertEquals(new TreeMap<String, Object>(), dict.toMap());
     }
 
     @Test
@@ -110,14 +110,14 @@ public class DictionaryTest extends BaseTest {
         assertEquals(level2, doc.getDictionary("level2"));
         assertEquals(level3, doc.getDictionary("level3"));
 
-        Map<String, Object> dict = new HashMap<>();
-        Map<String, Object> l1 = new HashMap<>();
+        Map<String, Object> dict = new TreeMap<>();
+        Map<String, Object> l1 = new TreeMap<>();
         l1.put("name", "n1");
         dict.put("level1", l1);
-        Map<String, Object> l2 = new HashMap<>();
+        Map<String, Object> l2 = new TreeMap<>();
         l2.put("name", "n2");
         dict.put("level2", l2);
-        Map<String, Object> l3 = new HashMap<>();
+        Map<String, Object> l3 = new TreeMap<>();
         l3.put("name", "n3");
         dict.put("level3", l3);
         assertEquals(dict, doc.toMap());
@@ -135,16 +135,16 @@ public class DictionaryTest extends BaseTest {
 
         List<Object> data = new ArrayList<>();
 
-        Map<String, Object> d1 = new HashMap<>();
+        Map<String, Object> d1 = new TreeMap<>();
         d1.put("name", "1");
         data.add(d1);
-        Map<String, Object> d2 = new HashMap<>();
+        Map<String, Object> d2 = new TreeMap<>();
         d2.put("name", "2");
         data.add(d2);
-        Map<String, Object> d3 = new HashMap<>();
+        Map<String, Object> d3 = new TreeMap<>();
         d3.put("name", "3");
         data.add(d3);
-        Map<String, Object> d4 = new HashMap<>();
+        Map<String, Object> d4 = new TreeMap<>();
         d4.put("name", "4");
         data.add(d4);
         assertEquals(4, data.size());
@@ -277,7 +277,7 @@ public class DictionaryTest extends BaseTest {
             dict.set(String.format(Locale.ENGLISH, "key%d", i), i);
         Map<String, Object> content = dict.toMap();
 
-        Map<String, Object> result = new HashMap<>();
+        Map<String, Object> result = new TreeMap<>();
         int count = 0;
         for (String key : dict) {
             result.put(key, dict.getObject(key));
@@ -292,7 +292,7 @@ public class DictionaryTest extends BaseTest {
         dict.set("key21", 21);
         content = dict.toMap();
 
-        result = new HashMap<>();
+        result = new TreeMap<>();
         count = 0;
         for (String key : dict) {
             result.put(key, dict.getObject(key));
@@ -308,7 +308,7 @@ public class DictionaryTest extends BaseTest {
         save(doc, new Validator<Document>() {
             @Override
             public void validate(Document doc) {
-                Map<String, Object> result = new HashMap<>();
+                Map<String, Object> result = new TreeMap<>();
                 int count = 0;
                 Dictionary dictObj = doc.getDictionary("dict");
                 for (String key : dictObj) {

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
@@ -8,7 +8,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -21,7 +21,7 @@ public class DictionaryTest extends BaseTest {
     public void testCreateDictionary() {
         Dictionary address = new Dictionary();
         assertEquals(0, address.count());
-        assertEquals(new TreeMap<String, Object>(), address.toMap());
+        assertEquals(new HashMap<String, Object>(), address.toMap());
 
         Document doc = createDocument("doc1");
         doc.set("address", address);
@@ -29,12 +29,12 @@ public class DictionaryTest extends BaseTest {
 
         save(doc);
         doc = db.getDocument("doc1");
-        assertEquals(new TreeMap<String, Object>(), doc.getDictionary("address").toMap());
+        assertEquals(new HashMap<String, Object>(), doc.getDictionary("address").toMap());
     }
 
     @Test
     public void testCreateDictionaryWithNSDictionary() {
-        Map<String, Object> dict = new TreeMap<>();
+        Map<String, Object> dict = new HashMap<>();
         dict.put("street", "1 Main street");
         dict.put("city", "Mountain View");
         dict.put("state", "CA");
@@ -69,7 +69,7 @@ public class DictionaryTest extends BaseTest {
         assertTrue(dict.getString("key") == null);
         assertTrue(dict.getDictionary("key") == null);
         assertTrue(dict.getArray("key") == null);
-        assertEquals(new TreeMap<String, Object>(), dict.toMap());
+        assertEquals(new HashMap<String, Object>(), dict.toMap());
 
         Document doc = createDocument("doc1");
         doc.set("dict", dict);
@@ -90,7 +90,7 @@ public class DictionaryTest extends BaseTest {
         assertTrue(dict.getString("key") == null);
         assertTrue(dict.getDictionary("key") == null);
         assertTrue(dict.getArray("key") == null);
-        assertEquals(new TreeMap<String, Object>(), dict.toMap());
+        assertEquals(new HashMap<String, Object>(), dict.toMap());
     }
 
     @Test
@@ -113,14 +113,14 @@ public class DictionaryTest extends BaseTest {
         assertEquals(level2, doc.getDictionary("level2"));
         assertEquals(level3, doc.getDictionary("level3"));
 
-        Map<String, Object> dict = new TreeMap<>();
-        Map<String, Object> l1 = new TreeMap<>();
+        Map<String, Object> dict = new HashMap<>();
+        Map<String, Object> l1 = new HashMap<>();
         l1.put("name", "n1");
         dict.put("level1", l1);
-        Map<String, Object> l2 = new TreeMap<>();
+        Map<String, Object> l2 = new HashMap<>();
         l2.put("name", "n2");
         dict.put("level2", l2);
-        Map<String, Object> l3 = new TreeMap<>();
+        Map<String, Object> l3 = new HashMap<>();
         l3.put("name", "n3");
         dict.put("level3", l3);
         assertEquals(dict, doc.toMap());
@@ -138,16 +138,16 @@ public class DictionaryTest extends BaseTest {
 
         List<Object> data = new ArrayList<>();
 
-        Map<String, Object> d1 = new TreeMap<>();
+        Map<String, Object> d1 = new HashMap<>();
         d1.put("name", "1");
         data.add(d1);
-        Map<String, Object> d2 = new TreeMap<>();
+        Map<String, Object> d2 = new HashMap<>();
         d2.put("name", "2");
         data.add(d2);
-        Map<String, Object> d3 = new TreeMap<>();
+        Map<String, Object> d3 = new HashMap<>();
         d3.put("name", "3");
         data.add(d3);
-        Map<String, Object> d4 = new TreeMap<>();
+        Map<String, Object> d4 = new HashMap<>();
         d4.put("name", "4");
         data.add(d4);
         assertEquals(4, data.size());
@@ -280,7 +280,7 @@ public class DictionaryTest extends BaseTest {
             dict.set(String.format(Locale.ENGLISH, "key%d", i), i);
         Map<String, Object> content = dict.toMap();
 
-        Map<String, Object> result = new TreeMap<>();
+        Map<String, Object> result = new HashMap<>();
         int count = 0;
         for (String key : dict) {
             result.put(key, dict.getObject(key));
@@ -295,7 +295,7 @@ public class DictionaryTest extends BaseTest {
         dict.set("key21", 21);
         content = dict.toMap();
 
-        result = new TreeMap<>();
+        result = new HashMap<>();
         count = 0;
         for (String key : dict) {
             result.put(key, dict.getObject(key));
@@ -311,7 +311,7 @@ public class DictionaryTest extends BaseTest {
         save(doc, new Validator<Document>() {
             @Override
             public void validate(Document doc) {
-                Map<String, Object> result = new TreeMap<>();
+                Map<String, Object> result = new HashMap<>();
                 int count = 0;
                 Dictionary dictObj = doc.getDictionary("dict");
                 for (String key : dictObj) {

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
@@ -862,7 +862,7 @@ public class DocumentTest extends BaseTest {
         save(doc);
         doc = db.getDocument("doc1");
 
-        Log.e(TAG, "doc.allKeys() -> " + doc.allKeys());
+        Log.e(TAG, "doc.getKeys() -> " + doc.getKeys());
         assertTrue(dict != doc.getObject("dict"));
         assertEquals(doc.getObject("dict"), doc.getDictionary("dict"));
         assertEquals(map, doc.getDictionary("dict").toMap());

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
@@ -25,9 +25,9 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 import static com.couchbase.litecore.Constants.C4ErrorDomain.LiteCoreDomain;
 import static com.couchbase.litecore.Constants.LiteCoreError.kC4ErrorBadDocID;
@@ -91,7 +91,7 @@ public class DocumentTest extends BaseTest {
         assertNotNull(doc1a);
         assertTrue(doc1a.getId().length() > 0);
         assertFalse(doc1a.isDeleted());
-        assertEquals(new HashMap<String, Object>(), doc1a.toMap());
+        assertEquals(new TreeMap<String, Object>(), doc1a.toMap());
 
         save(doc1a);
         Document doc1b = db.getDocument(doc1a.getId());
@@ -109,7 +109,7 @@ public class DocumentTest extends BaseTest {
         assertNotNull(doc1a);
         assertEquals("doc1", doc1a.getId());
         assertFalse(doc1a.isDeleted());
-        assertEquals(new HashMap<String, Object>(), doc1a.toMap());
+        assertEquals(new TreeMap<String, Object>(), doc1a.toMap());
 
         save(doc1a);
         Document doc1b = db.getDocument("doc1");
@@ -139,7 +139,7 @@ public class DocumentTest extends BaseTest {
         assertNotNull(doc1a);
         assertTrue(doc1a.getId().length() > 0);
         assertFalse(doc1a.isDeleted());
-        assertEquals(new HashMap<String, Object>(), doc1a.toMap());
+        assertEquals(new TreeMap<String, Object>(), doc1a.toMap());
 
         save(doc1a);
         Document doc1b = db.getDocument(doc1a.getId());
@@ -152,11 +152,11 @@ public class DocumentTest extends BaseTest {
 
     @Test
     public void testCreateDocWithDict() {
-        Map<String, Object> dict = new HashMap<>();
+        Map<String, Object> dict = new TreeMap<>();
         dict.put("name", "Scott Tiger");
         dict.put("age", 30);
 
-        Map<String, Object> address = new HashMap<>();
+        Map<String, Object> address = new TreeMap<>();
         address.put("street", "1 Main street");
         address.put("city", "Mountain View");
         address.put("state", "CA");
@@ -177,16 +177,16 @@ public class DocumentTest extends BaseTest {
         assertTrue(doc1b.exists());
         assertFalse(doc1b.isDeleted());
         assertEquals(doc1a.getId(), doc1b.getId());
-        assertEquals(dict, doc1b.toMap());
+        assertEquals(dict.toString(), doc1b.toMap().toString());
     }
 
     @Test
     public void testCreateDocWithIDAndDict() {
-        Map<String, Object> dict = new HashMap<>();
+        Map<String, Object> dict = new TreeMap<>();
         dict.put("name", "Scott Tiger");
         dict.put("age", 30);
 
-        Map<String, Object> address = new HashMap<>();
+        Map<String, Object> address = new TreeMap<>();
         address.put("street", "1 Main street");
         address.put("city", "Mountain View");
         address.put("state", "CA");
@@ -207,16 +207,16 @@ public class DocumentTest extends BaseTest {
         assertTrue(doc1b.exists());
         assertFalse(doc1b.isDeleted());
         assertEquals(doc1a.getId(), doc1b.getId());
-        assertEquals(dict, doc1b.toMap());
+        assertEquals(dict.toString(), doc1b.toMap().toString());
     }
 
     @Test
     public void testSetDictionaryContent() {
-        Map<String, Object> dict = new HashMap<>();
+        Map<String, Object> dict = new TreeMap<>();
         dict.put("name", "Scott Tiger");
         dict.put("age", 30);
 
-        Map<String, Object> address = new HashMap<>();
+        Map<String, Object> address = new TreeMap<>();
         address.put("street", "1 Main street");
         address.put("city", "Mountain View");
         address.put("state", "CA");
@@ -230,13 +230,13 @@ public class DocumentTest extends BaseTest {
 
         save(doc);
         doc = db.getDocument("doc1");
-        assertEquals(dict, doc.toMap());
+        assertEquals(dict.toString(), doc.toMap().toString());
 
-        Map<String, Object> nuDict = new HashMap<>();
+        Map<String, Object> nuDict = new TreeMap<>();
         nuDict.put("name", "Danial Tiger");
         nuDict.put("age", 32);
 
-        Map<String, Object> nuAddress = new HashMap<>();
+        Map<String, Object> nuAddress = new TreeMap<>();
         nuAddress.put("street", "2 Main street");
         nuAddress.put("city", "Palo Alto");
         nuAddress.put("state", "CA");
@@ -249,7 +249,7 @@ public class DocumentTest extends BaseTest {
 
         save(doc);
         doc = db.getDocument("doc1");
-        assertEquals(nuDict, doc.toMap());
+        assertEquals(nuDict.toString(), doc.toMap().toString());
     }
 
 
@@ -270,7 +270,7 @@ public class DocumentTest extends BaseTest {
                 assertNull(d.getString("key"));
                 assertNull(d.getArray("key"));
                 assertNull(d.getDictionary("key"));
-                assertEquals(new HashMap<>(), d.toMap());
+                assertEquals(new TreeMap<>(), d.toMap());
             }
         });
     }
@@ -292,7 +292,7 @@ public class DocumentTest extends BaseTest {
         assertNull(doc.getString("key"));
         assertNull(doc.getArray("key"));
         assertNull(doc.getDictionary("key"));
-        assertEquals(new HashMap<>(), doc.toMap());
+        assertEquals(new TreeMap<>(), doc.toMap());
     }
 
 
@@ -404,9 +404,9 @@ public class DocumentTest extends BaseTest {
         save(doc, new Validator<Document>() {
             @Override
             public void validate(Document d) {
-                assertEquals(1, d.getObject("number1"));
-                assertEquals(0, d.getObject("number2"));
-                assertEquals(-1, d.getObject("number3"));
+                assertEquals(1, ((Number)d.getObject("number1")).intValue());
+                assertEquals(0, ((Number)d.getObject("number2")).intValue());
+                assertEquals(-1, ((Number)d.getObject("number3")).intValue());
                 assertEquals(1.1, d.getObject("number4"));
             }
         });
@@ -421,10 +421,10 @@ public class DocumentTest extends BaseTest {
         save(doc, new Validator<Document>() {
             @Override
             public void validate(Document d) {
-                assertEquals(0, d.getObject("number1"));
-                assertEquals(1, d.getObject("number2"));
+                assertEquals(0, ((Number)d.getObject("number1")).intValue());
+                assertEquals(1, ((Number)d.getObject("number2")).intValue());
                 assertEquals(1.1, d.getObject("number3"));
-                assertEquals(-1, d.getObject("number4"));
+                assertEquals(-1, ((Number)d.getObject("number4")).intValue());
             }
         });
     }
@@ -440,9 +440,9 @@ public class DocumentTest extends BaseTest {
                 assertNull(d.getNumber("true"));
                 assertNull(d.getNumber("false"));
                 assertNull(d.getNumber("string"));
-                assertEquals(0, d.getNumber("zero"));
-                assertEquals(1, d.getNumber("one"));
-                assertEquals(-1, d.getNumber("minus_one"));
+                assertEquals(0, d.getNumber("zero").intValue());
+                assertEquals(1, d.getNumber("one").intValue());
+                assertEquals(-1, d.getNumber("minus_one").intValue());
                 assertEquals(1.1, d.getNumber("one_dot_one"));
                 assertNull(d.getNumber("date"));
                 assertNull(d.getNumber("dict"));
@@ -569,20 +569,19 @@ public class DocumentTest extends BaseTest {
         save(doc, new Validator<Document>() {
             @Override
             public void validate(Document doc) {
-                assertEquals(Integer.MIN_VALUE, doc.getNumber("min_int"));
-                assertEquals(Integer.MAX_VALUE, doc.getNumber("max_int"));
-                assertEquals(Integer.MIN_VALUE, doc.getObject("min_int"));
-                assertEquals(Integer.MAX_VALUE, doc.getObject("max_int"));
+                assertEquals(Integer.MIN_VALUE, doc.getNumber("min_int").intValue());
+                assertEquals(Integer.MAX_VALUE, doc.getNumber("max_int").intValue());
+                assertEquals(Integer.MIN_VALUE, ((Number)doc.getObject("min_int")).intValue());
+                assertEquals(Integer.MAX_VALUE, ((Number)doc.getObject("max_int")).intValue());
                 assertEquals(Integer.MIN_VALUE, doc.getInt("min_int"));
                 assertEquals(Integer.MAX_VALUE, doc.getInt("max_int"));
 
-                //TODO: Long does not work with current implementation
-//                assertEquals(Long.MIN_VALUE, doc.getNumber("min_long"));
-//                assertEquals(Long.MAX_VALUE, doc.getNumber("max_long"));
-//                assertEquals(Long.MIN_VALUE, doc.getObject("min_long"));
-//                assertEquals(Long.MAX_VALUE, doc.getObject("max_long"));
-//                assertEquals(Long.MIN_VALUE, doc.getLong("min_long"));
-//                assertEquals(Long.MAX_VALUE, doc.getLong("max_long"));
+                assertEquals(Long.MIN_VALUE, doc.getNumber("min_long"));
+                assertEquals(Long.MAX_VALUE, doc.getNumber("max_long"));
+                assertEquals(Long.MIN_VALUE, doc.getObject("min_long"));
+                assertEquals(Long.MAX_VALUE, doc.getObject("max_long"));
+                assertEquals(Long.MIN_VALUE, doc.getLong("min_long"));
+                assertEquals(Long.MAX_VALUE, doc.getLong("max_long"));
 
                 assertEquals(Float.MIN_VALUE, doc.getNumber("min_float"));
                 assertEquals(Float.MAX_VALUE, doc.getNumber("max_float"));
@@ -854,7 +853,7 @@ public class DocumentTest extends BaseTest {
         dict.set("city", "Mountain View");
 
         assertEquals(doc.getObject("dict"), doc.getDictionary("dict"));
-        Map<String, Object> map = new HashMap<>();
+        Map<String, Object> map = new TreeMap<>();
         map.put("street", "1 Main street");
         map.put("city", "Mountain View");
         assertEquals(map, doc.getDictionary("dict").toMap());
@@ -885,7 +884,7 @@ public class DocumentTest extends BaseTest {
                 assertNull(d.getDictionary("one_dot_one"));
                 assertNull(d.getDictionary("date"));
                 assertNotNull(d.getDictionary("dict"));
-                Map<String, Object> dict = new HashMap<>();
+                Map<String, Object> dict = new TreeMap<>();
                 dict.put("street", "1 Main street");
                 dict.put("city", "Mountain View");
                 dict.put("state", "CA");
@@ -971,7 +970,7 @@ public class DocumentTest extends BaseTest {
 
     @Test
     public void testSetMap() {
-        Map<String, Object> dict = new HashMap<>();
+        Map<String, Object> dict = new TreeMap<>();
         dict.put("street", "1 Main street");
         dict.put("city", "Mountain View");
         dict.put("state", "CA");
@@ -988,7 +987,7 @@ public class DocumentTest extends BaseTest {
         assertEquals(dict, address.toMap());
 
         // Update with a new dictionary:
-        Map<String, Object> nuDict = new HashMap<>();
+        Map<String, Object> nuDict = new TreeMap<>();
         nuDict.put("street", "1 Second street");
         nuDict.put("city", "Palo Alto");
         nuDict.put("state", "CA");
@@ -1015,7 +1014,7 @@ public class DocumentTest extends BaseTest {
         doc = db.getDocument(doc.getId());
 
         nuDict.put("zip", "94302");
-        Map<String, Object> expected = new HashMap<>();
+        Map<String, Object> expected = new TreeMap<>();
         expected.put("address", nuDict);
         assertEquals(expected, doc.toMap());
     }
@@ -1062,7 +1061,7 @@ public class DocumentTest extends BaseTest {
         save(doc);
         doc = db.getDocument("doc1");
 
-        Map<String, Object> expected = new HashMap<>();
+        Map<String, Object> expected = new TreeMap<>();
         expected.put("members", Arrays.asList("d", "e", "f", "g"));
         assertEquals(expected, doc.toMap());
     }
@@ -1086,14 +1085,14 @@ public class DocumentTest extends BaseTest {
 
         doc = save(doc);
 
-        Map<String, Object> mapShipping = new HashMap<>();
+        Map<String, Object> mapShipping = new TreeMap<>();
         mapShipping.put("street", "1 Main street");
         mapShipping.put("city", "Mountain View");
         mapShipping.put("state", "CA");
         mapShipping.put("zip", "94042");
-        Map<String, Object> mapAddresses = new HashMap<>();
+        Map<String, Object> mapAddresses = new TreeMap<>();
         mapAddresses.put("shipping", mapShipping);
-        Map<String, Object> expected = new HashMap<>();
+        Map<String, Object> expected = new TreeMap<>();
         expected.put("addresses", mapAddresses);
 
         assertEquals(expected, doc.toMap());
@@ -1129,19 +1128,19 @@ public class DocumentTest extends BaseTest {
 
         doc = save(doc);
 
-        Map<String, Object> mapAddress1 = new HashMap<>();
+        Map<String, Object> mapAddress1 = new TreeMap<>();
         mapAddress1.put("street", "2 Main street");
         mapAddress1.put("city", "Mountain View");
         mapAddress1.put("state", "CA");
         mapAddress1.put("zip", "94042");
 
-        Map<String, Object> mapAddress2 = new HashMap<>();
+        Map<String, Object> mapAddress2 = new TreeMap<>();
         mapAddress2.put("street", "2 Second street");
         mapAddress2.put("city", "Palo Alto");
         mapAddress2.put("state", "CA");
         mapAddress2.put("zip", "94302");
 
-        Map<String, Object> expected = new HashMap<>();
+        Map<String, Object> expected = new TreeMap<>();
         expected.put("addresses", Arrays.asList(mapAddress1, mapAddress2));
 
         assertEquals(expected, doc.toMap());
@@ -1179,9 +1178,9 @@ public class DocumentTest extends BaseTest {
 
         doc = save(doc);
 
-        Map<String, Object> expected = new HashMap<>();
+        Map<String, Object> expected = new TreeMap<>();
         expected.put("groups", Arrays.asList(Arrays.asList("d", "e", "f"), Arrays.asList(4, 5, 6)));
-        assertEquals(expected, doc.toMap());
+        assertEquals(expected.toString(), doc.toMap().toString());
     }
 
     @Test
@@ -1218,14 +1217,14 @@ public class DocumentTest extends BaseTest {
 
         doc = save(doc);
 
-        Map<String, Object> expected = new HashMap<>();
-        Map<String, Object> mapGroup1 = new HashMap<>();
+        Map<String, Object> expected = new TreeMap<>();
+        Map<String, Object> mapGroup1 = new TreeMap<>();
         mapGroup1.put("member", Arrays.asList("d", "e", "f"));
-        Map<String, Object> mapGroup2 = new HashMap<>();
+        Map<String, Object> mapGroup2 = new TreeMap<>();
         mapGroup2.put("member", Arrays.asList(4, 5, 6));
         expected.put("group1", mapGroup1);
         expected.put("group2", mapGroup2);
-        assertEquals(expected, doc.toMap());
+        assertEquals(expected.toString(), doc.toMap().toString());
     }
 
     @Test
@@ -1327,11 +1326,11 @@ public class DocumentTest extends BaseTest {
     @Test
     public void testRemoveKeys() {
         Document doc = createDocument("doc1");
-        Map<String, Object> mapAddress = new HashMap<>();
+        Map<String, Object> mapAddress = new TreeMap<>();
         mapAddress.put("street", "1 milky way.");
         mapAddress.put("city", "galaxy city");
         mapAddress.put("zip", 12345);
-        Map<String, Object> profile = new HashMap<>();
+        Map<String, Object> profile = new TreeMap<>();
         profile.put("type", "profile");
         profile.put("name", "Jason");
         profile.put("weight", 130.5);
@@ -1361,28 +1360,28 @@ public class DocumentTest extends BaseTest {
         assertNull(doc.getDictionary("address").getObject("city"));
 
         Dictionary address = doc.getDictionary("address");
-        Map<String, Object> addr = new HashMap<>();
+        Map<String, Object> addr = new TreeMap<>();
         addr.put("street", "1 milky way.");
         addr.put("zip", 12345);
-        assertEquals(addr, address.toMap());
-        Map<String, Object> expected = new HashMap<>();
+        assertEquals(addr.toString(), address.toMap().toString());
+        Map<String, Object> expected = new TreeMap<>();
         expected.put("type", "profile");
         expected.put("address", addr);
-        assertEquals(expected, doc.toMap());
+        assertEquals(expected.toString(), doc.toMap().toString());
 
         doc.remove("type");
         doc.remove("address");
         assertNull(doc.getObject("type"));
         assertNull(doc.getObject("address"));
-        assertEquals(new HashMap<>(), doc.toMap());
+        assertEquals(new TreeMap<>(), doc.toMap());
     }
 
     @Test
     public void testContainsKey() {
         Document doc = createDocument("doc1");
-        Map<String, Object> mapAddress = new HashMap<>();
+        Map<String, Object> mapAddress = new TreeMap<>();
         mapAddress.put("street", "1 milky way.");
-        Map<String, Object> profile = new HashMap<>();
+        Map<String, Object> profile = new TreeMap<>();
         profile.put("type", "profile");
         profile.put("name", "Jason");
         profile.put("age", 30);
@@ -1424,16 +1423,16 @@ public class DocumentTest extends BaseTest {
         db.delete(doc);
         assertTrue(doc.isDeleted());
         assertNull(doc.getObject("name"));
-        assertEquals(new HashMap<>(), doc.toMap());
+        assertEquals(new TreeMap<>(), doc.toMap());
     }
 
     @Test
     public void testDictionaryAfterDeleteDocument() {
-        Map<String, Object> addr = new HashMap<>();
+        Map<String, Object> addr = new TreeMap<>();
         addr.put("street", "1 Main street");
         addr.put("city", "Mountain View");
         addr.put("state", "CA");
-        Map<String, Object> dict = new HashMap<>();
+        Map<String, Object> dict = new TreeMap<>();
         dict.put("address", addr);
 
         Document doc = createDocument("doc1", dict);
@@ -1446,7 +1445,7 @@ public class DocumentTest extends BaseTest {
 
         db.delete(doc);
         assertNull(doc.getDictionary("address"));
-        assertEquals(new HashMap<>(), doc.toMap());
+        assertEquals(new TreeMap<>(), doc.toMap());
 
         // The dictionary still has data but is detached:
         assertEquals("1 Main street", address.getObject("street"));
@@ -1456,12 +1455,12 @@ public class DocumentTest extends BaseTest {
         // Make changes to the dictionary shouldn't affect the document.
         address.set("zip", "94042");
         assertNull(doc.getDictionary("address"));
-        assertEquals(new HashMap<>(), doc.toMap());
+        assertEquals(new TreeMap<>(), doc.toMap());
     }
 
     @Test
     public void testArrayAfterDeleteDocument() {
-        Map<String, Object> dict = new HashMap<>();
+        Map<String, Object> dict = new TreeMap<>();
         dict.put("members", Arrays.asList("a", "b", "c"));
 
         Document doc = createDocument("doc1", dict);
@@ -1476,7 +1475,7 @@ public class DocumentTest extends BaseTest {
 
         db.delete(doc);
         assertNull(doc.getDictionary("members"));
-        assertEquals(new HashMap<>(), doc.toMap());
+        assertEquals(new TreeMap<>(), doc.toMap());
 
         // The array still has data but is detached:
 
@@ -1489,7 +1488,7 @@ public class DocumentTest extends BaseTest {
         members.set(2, "1");
         members.add("2");
         assertNull(doc.getDictionary("members"));
-        assertEquals(new HashMap<>(), doc.toMap());
+        assertEquals(new TreeMap<>(), doc.toMap());
 
     }
 
@@ -1531,7 +1530,7 @@ public class DocumentTest extends BaseTest {
 
         doc = db.getDocument("doc1");
         assertEquals("str", doc.getString("string"));
-        Map<String, Object> expected = new HashMap<>();
+        Map<String, Object> expected = new TreeMap<>();
         expected.put("string", "str");
         assertEquals(expected, doc.toMap());
     }

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
@@ -27,7 +27,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
-import java.util.TreeMap;
+import java.util.HashMap;
 
 import static com.couchbase.litecore.Constants.C4ErrorDomain.LiteCoreDomain;
 import static com.couchbase.litecore.Constants.LiteCoreError.kC4ErrorBadDocID;
@@ -91,7 +91,7 @@ public class DocumentTest extends BaseTest {
         assertNotNull(doc1a);
         assertTrue(doc1a.getId().length() > 0);
         assertFalse(doc1a.isDeleted());
-        assertEquals(new TreeMap<String, Object>(), doc1a.toMap());
+        assertEquals(new HashMap<String, Object>(), doc1a.toMap());
 
         save(doc1a);
         Document doc1b = db.getDocument(doc1a.getId());
@@ -109,7 +109,7 @@ public class DocumentTest extends BaseTest {
         assertNotNull(doc1a);
         assertEquals("doc1", doc1a.getId());
         assertFalse(doc1a.isDeleted());
-        assertEquals(new TreeMap<String, Object>(), doc1a.toMap());
+        assertEquals(new HashMap<String, Object>(), doc1a.toMap());
 
         save(doc1a);
         Document doc1b = db.getDocument("doc1");
@@ -139,7 +139,7 @@ public class DocumentTest extends BaseTest {
         assertNotNull(doc1a);
         assertTrue(doc1a.getId().length() > 0);
         assertFalse(doc1a.isDeleted());
-        assertEquals(new TreeMap<String, Object>(), doc1a.toMap());
+        assertEquals(new HashMap<String, Object>(), doc1a.toMap());
 
         save(doc1a);
         Document doc1b = db.getDocument(doc1a.getId());
@@ -152,11 +152,11 @@ public class DocumentTest extends BaseTest {
 
     @Test
     public void testCreateDocWithDict() {
-        Map<String, Object> dict = new TreeMap<>();
+        Map<String, Object> dict = new HashMap<>();
         dict.put("name", "Scott Tiger");
-        dict.put("age", 30);
+        dict.put("age", 30L);
 
-        Map<String, Object> address = new TreeMap<>();
+        Map<String, Object> address = new HashMap<>();
         address.put("street", "1 Main street");
         address.put("city", "Mountain View");
         address.put("state", "CA");
@@ -177,16 +177,16 @@ public class DocumentTest extends BaseTest {
         assertTrue(doc1b.exists());
         assertFalse(doc1b.isDeleted());
         assertEquals(doc1a.getId(), doc1b.getId());
-        assertEquals(dict.toString(), doc1b.toMap().toString());
+        assertEquals(dict, doc1b.toMap());
     }
 
     @Test
     public void testCreateDocWithIDAndDict() {
-        Map<String, Object> dict = new TreeMap<>();
+        Map<String, Object> dict = new HashMap<>();
         dict.put("name", "Scott Tiger");
-        dict.put("age", 30);
+        dict.put("age", 30L);
 
-        Map<String, Object> address = new TreeMap<>();
+        Map<String, Object> address = new HashMap<>();
         address.put("street", "1 Main street");
         address.put("city", "Mountain View");
         address.put("state", "CA");
@@ -207,16 +207,16 @@ public class DocumentTest extends BaseTest {
         assertTrue(doc1b.exists());
         assertFalse(doc1b.isDeleted());
         assertEquals(doc1a.getId(), doc1b.getId());
-        assertEquals(dict.toString(), doc1b.toMap().toString());
+        assertEquals(dict, doc1b.toMap());
     }
 
     @Test
     public void testSetDictionaryContent() {
-        Map<String, Object> dict = new TreeMap<>();
+        Map<String, Object> dict = new HashMap<>();
         dict.put("name", "Scott Tiger");
-        dict.put("age", 30);
+        dict.put("age", 30L);
 
-        Map<String, Object> address = new TreeMap<>();
+        Map<String, Object> address = new HashMap<>();
         address.put("street", "1 Main street");
         address.put("city", "Mountain View");
         address.put("state", "CA");
@@ -230,13 +230,13 @@ public class DocumentTest extends BaseTest {
 
         save(doc);
         doc = db.getDocument("doc1");
-        assertEquals(dict.toString(), doc.toMap().toString());
+        assertEquals(dict, doc.toMap());
 
-        Map<String, Object> nuDict = new TreeMap<>();
+        Map<String, Object> nuDict = new HashMap<>();
         nuDict.put("name", "Danial Tiger");
-        nuDict.put("age", 32);
+        nuDict.put("age", 32L);
 
-        Map<String, Object> nuAddress = new TreeMap<>();
+        Map<String, Object> nuAddress = new HashMap<>();
         nuAddress.put("street", "2 Main street");
         nuAddress.put("city", "Palo Alto");
         nuAddress.put("state", "CA");
@@ -249,7 +249,7 @@ public class DocumentTest extends BaseTest {
 
         save(doc);
         doc = db.getDocument("doc1");
-        assertEquals(nuDict.toString(), doc.toMap().toString());
+        assertEquals(nuDict, doc.toMap());
     }
 
 
@@ -270,7 +270,7 @@ public class DocumentTest extends BaseTest {
                 assertNull(d.getString("key"));
                 assertNull(d.getArray("key"));
                 assertNull(d.getDictionary("key"));
-                assertEquals(new TreeMap<>(), d.toMap());
+                assertEquals(new HashMap<>(), d.toMap());
             }
         });
     }
@@ -292,7 +292,7 @@ public class DocumentTest extends BaseTest {
         assertNull(doc.getString("key"));
         assertNull(doc.getArray("key"));
         assertNull(doc.getDictionary("key"));
-        assertEquals(new TreeMap<>(), doc.toMap());
+        assertEquals(new HashMap<>(), doc.toMap());
     }
 
 
@@ -853,7 +853,7 @@ public class DocumentTest extends BaseTest {
         dict.set("city", "Mountain View");
 
         assertEquals(doc.getObject("dict"), doc.getDictionary("dict"));
-        Map<String, Object> map = new TreeMap<>();
+        Map<String, Object> map = new HashMap<>();
         map.put("street", "1 Main street");
         map.put("city", "Mountain View");
         assertEquals(map, doc.getDictionary("dict").toMap());
@@ -884,7 +884,7 @@ public class DocumentTest extends BaseTest {
                 assertNull(d.getDictionary("one_dot_one"));
                 assertNull(d.getDictionary("date"));
                 assertNotNull(d.getDictionary("dict"));
-                Map<String, Object> dict = new TreeMap<>();
+                Map<String, Object> dict = new HashMap<>();
                 dict.put("street", "1 Main street");
                 dict.put("city", "Mountain View");
                 dict.put("state", "CA");
@@ -970,7 +970,7 @@ public class DocumentTest extends BaseTest {
 
     @Test
     public void testSetMap() {
-        Map<String, Object> dict = new TreeMap<>();
+        Map<String, Object> dict = new HashMap<>();
         dict.put("street", "1 Main street");
         dict.put("city", "Mountain View");
         dict.put("state", "CA");
@@ -987,7 +987,7 @@ public class DocumentTest extends BaseTest {
         assertEquals(dict, address.toMap());
 
         // Update with a new dictionary:
-        Map<String, Object> nuDict = new TreeMap<>();
+        Map<String, Object> nuDict = new HashMap<>();
         nuDict.put("street", "1 Second street");
         nuDict.put("city", "Palo Alto");
         nuDict.put("state", "CA");
@@ -1014,7 +1014,7 @@ public class DocumentTest extends BaseTest {
         doc = db.getDocument(doc.getId());
 
         nuDict.put("zip", "94302");
-        Map<String, Object> expected = new TreeMap<>();
+        Map<String, Object> expected = new HashMap<>();
         expected.put("address", nuDict);
         assertEquals(expected, doc.toMap());
     }
@@ -1061,7 +1061,7 @@ public class DocumentTest extends BaseTest {
         save(doc);
         doc = db.getDocument("doc1");
 
-        Map<String, Object> expected = new TreeMap<>();
+        Map<String, Object> expected = new HashMap<>();
         expected.put("members", Arrays.asList("d", "e", "f", "g"));
         assertEquals(expected, doc.toMap());
     }
@@ -1085,14 +1085,14 @@ public class DocumentTest extends BaseTest {
 
         doc = save(doc);
 
-        Map<String, Object> mapShipping = new TreeMap<>();
+        Map<String, Object> mapShipping = new HashMap<>();
         mapShipping.put("street", "1 Main street");
         mapShipping.put("city", "Mountain View");
         mapShipping.put("state", "CA");
         mapShipping.put("zip", "94042");
-        Map<String, Object> mapAddresses = new TreeMap<>();
+        Map<String, Object> mapAddresses = new HashMap<>();
         mapAddresses.put("shipping", mapShipping);
-        Map<String, Object> expected = new TreeMap<>();
+        Map<String, Object> expected = new HashMap<>();
         expected.put("addresses", mapAddresses);
 
         assertEquals(expected, doc.toMap());
@@ -1128,19 +1128,19 @@ public class DocumentTest extends BaseTest {
 
         doc = save(doc);
 
-        Map<String, Object> mapAddress1 = new TreeMap<>();
+        Map<String, Object> mapAddress1 = new HashMap<>();
         mapAddress1.put("street", "2 Main street");
         mapAddress1.put("city", "Mountain View");
         mapAddress1.put("state", "CA");
         mapAddress1.put("zip", "94042");
 
-        Map<String, Object> mapAddress2 = new TreeMap<>();
+        Map<String, Object> mapAddress2 = new HashMap<>();
         mapAddress2.put("street", "2 Second street");
         mapAddress2.put("city", "Palo Alto");
         mapAddress2.put("state", "CA");
         mapAddress2.put("zip", "94302");
 
-        Map<String, Object> expected = new TreeMap<>();
+        Map<String, Object> expected = new HashMap<>();
         expected.put("addresses", Arrays.asList(mapAddress1, mapAddress2));
 
         assertEquals(expected, doc.toMap());
@@ -1178,9 +1178,9 @@ public class DocumentTest extends BaseTest {
 
         doc = save(doc);
 
-        Map<String, Object> expected = new TreeMap<>();
-        expected.put("groups", Arrays.asList(Arrays.asList("d", "e", "f"), Arrays.asList(4, 5, 6)));
-        assertEquals(expected.toString(), doc.toMap().toString());
+        Map<String, Object> expected = new HashMap<>();
+        expected.put("groups", Arrays.asList(Arrays.asList("d", "e", "f"), Arrays.asList(4L, 5L, 6L)));
+        assertEquals(expected, doc.toMap());
     }
 
     @Test
@@ -1217,14 +1217,14 @@ public class DocumentTest extends BaseTest {
 
         doc = save(doc);
 
-        Map<String, Object> expected = new TreeMap<>();
-        Map<String, Object> mapGroup1 = new TreeMap<>();
+        Map<String, Object> expected = new HashMap<>();
+        Map<String, Object> mapGroup1 = new HashMap<>();
         mapGroup1.put("member", Arrays.asList("d", "e", "f"));
-        Map<String, Object> mapGroup2 = new TreeMap<>();
-        mapGroup2.put("member", Arrays.asList(4, 5, 6));
+        Map<String, Object> mapGroup2 = new HashMap<>();
+        mapGroup2.put("member", Arrays.asList(4L, 5L, 6L));
         expected.put("group1", mapGroup1);
         expected.put("group2", mapGroup2);
-        assertEquals(expected.toString(), doc.toMap().toString());
+        assertEquals(expected, doc.toMap());
     }
 
     @Test
@@ -1326,11 +1326,11 @@ public class DocumentTest extends BaseTest {
     @Test
     public void testRemoveKeys() {
         Document doc = createDocument("doc1");
-        Map<String, Object> mapAddress = new TreeMap<>();
+        Map<String, Object> mapAddress = new HashMap<>();
         mapAddress.put("street", "1 milky way.");
         mapAddress.put("city", "galaxy city");
         mapAddress.put("zip", 12345);
-        Map<String, Object> profile = new TreeMap<>();
+        Map<String, Object> profile = new HashMap<>();
         profile.put("type", "profile");
         profile.put("name", "Jason");
         profile.put("weight", 130.5);
@@ -1360,28 +1360,28 @@ public class DocumentTest extends BaseTest {
         assertNull(doc.getDictionary("address").getObject("city"));
 
         Dictionary address = doc.getDictionary("address");
-        Map<String, Object> addr = new TreeMap<>();
+        Map<String, Object> addr = new HashMap<>();
         addr.put("street", "1 milky way.");
-        addr.put("zip", 12345);
-        assertEquals(addr.toString(), address.toMap().toString());
-        Map<String, Object> expected = new TreeMap<>();
+        addr.put("zip", 12345L);
+        assertEquals(addr, address.toMap());
+        Map<String, Object> expected = new HashMap<>();
         expected.put("type", "profile");
         expected.put("address", addr);
-        assertEquals(expected.toString(), doc.toMap().toString());
+        assertEquals(expected, doc.toMap());
 
         doc.remove("type");
         doc.remove("address");
         assertNull(doc.getObject("type"));
         assertNull(doc.getObject("address"));
-        assertEquals(new TreeMap<>(), doc.toMap());
+        assertEquals(new HashMap<>(), doc.toMap());
     }
 
     @Test
     public void testContainsKey() {
         Document doc = createDocument("doc1");
-        Map<String, Object> mapAddress = new TreeMap<>();
+        Map<String, Object> mapAddress = new HashMap<>();
         mapAddress.put("street", "1 milky way.");
-        Map<String, Object> profile = new TreeMap<>();
+        Map<String, Object> profile = new HashMap<>();
         profile.put("type", "profile");
         profile.put("name", "Jason");
         profile.put("age", 30);
@@ -1423,16 +1423,16 @@ public class DocumentTest extends BaseTest {
         db.delete(doc);
         assertTrue(doc.isDeleted());
         assertNull(doc.getObject("name"));
-        assertEquals(new TreeMap<>(), doc.toMap());
+        assertEquals(new HashMap<>(), doc.toMap());
     }
 
     @Test
     public void testDictionaryAfterDeleteDocument() {
-        Map<String, Object> addr = new TreeMap<>();
+        Map<String, Object> addr = new HashMap<>();
         addr.put("street", "1 Main street");
         addr.put("city", "Mountain View");
         addr.put("state", "CA");
-        Map<String, Object> dict = new TreeMap<>();
+        Map<String, Object> dict = new HashMap<>();
         dict.put("address", addr);
 
         Document doc = createDocument("doc1", dict);
@@ -1445,7 +1445,7 @@ public class DocumentTest extends BaseTest {
 
         db.delete(doc);
         assertNull(doc.getDictionary("address"));
-        assertEquals(new TreeMap<>(), doc.toMap());
+        assertEquals(new HashMap<>(), doc.toMap());
 
         // The dictionary still has data but is detached:
         assertEquals("1 Main street", address.getObject("street"));
@@ -1455,12 +1455,12 @@ public class DocumentTest extends BaseTest {
         // Make changes to the dictionary shouldn't affect the document.
         address.set("zip", "94042");
         assertNull(doc.getDictionary("address"));
-        assertEquals(new TreeMap<>(), doc.toMap());
+        assertEquals(new HashMap<>(), doc.toMap());
     }
 
     @Test
     public void testArrayAfterDeleteDocument() {
-        Map<String, Object> dict = new TreeMap<>();
+        Map<String, Object> dict = new HashMap<>();
         dict.put("members", Arrays.asList("a", "b", "c"));
 
         Document doc = createDocument("doc1", dict);
@@ -1475,7 +1475,7 @@ public class DocumentTest extends BaseTest {
 
         db.delete(doc);
         assertNull(doc.getDictionary("members"));
-        assertEquals(new TreeMap<>(), doc.toMap());
+        assertEquals(new HashMap<>(), doc.toMap());
 
         // The array still has data but is detached:
 
@@ -1488,7 +1488,7 @@ public class DocumentTest extends BaseTest {
         members.set(2, "1");
         members.add("2");
         assertNull(doc.getDictionary("members"));
-        assertEquals(new TreeMap<>(), doc.toMap());
+        assertEquals(new HashMap<>(), doc.toMap());
 
     }
 
@@ -1530,7 +1530,7 @@ public class DocumentTest extends BaseTest {
 
         doc = db.getDocument("doc1");
         assertEquals("str", doc.getString("string"));
-        Map<String, Object> expected = new TreeMap<>();
+        Map<String, Object> expected = new HashMap<>();
         expected.put("string", "str");
         assertEquals(expected, doc.toMap());
     }

--- a/android/CouchbaseLite/src/main/java/com/couchbase/lite/DatabaseConfiguration.java
+++ b/android/CouchbaseLite/src/main/java/com/couchbase/lite/DatabaseConfiguration.java
@@ -5,7 +5,12 @@ import android.content.Context;
 public class DatabaseConfiguration extends BaseDatabaseConfiguration {
     private Context context;
 
-    public DatabaseConfiguration() {
+    //---------------------------------------------
+    // Constructors
+    //---------------------------------------------
+
+    private DatabaseConfiguration() {
+        // only for copy() method.
     }
 
     public DatabaseConfiguration(Context context) {

--- a/android/CouchbaseLite/src/main/java/com/couchbase/lite/DatabaseConfiguration.java
+++ b/android/CouchbaseLite/src/main/java/com/couchbase/lite/DatabaseConfiguration.java
@@ -2,7 +2,7 @@ package com.couchbase.lite;
 
 import android.content.Context;
 
-public class DatabaseConfiguration extends BaseDatabaseConfiguration{
+public class DatabaseConfiguration extends BaseDatabaseConfiguration {
     private Context context;
 
     public DatabaseConfiguration() {
@@ -19,7 +19,7 @@ public class DatabaseConfiguration extends BaseDatabaseConfiguration{
     //---------------------------------------------
 
     /* package */ DatabaseConfiguration copy() {
-        DatabaseConfiguration config =  new DatabaseConfiguration();
+        DatabaseConfiguration config = new DatabaseConfiguration();
         config.context = this.context;
         config.setConflictResolver(this.getConflictResolver());
         config.setDirectory(this.getDirectory());

--- a/android/CouchbaseLite/src/main/java/com/couchbase/lite/DatabaseConfiguration.java
+++ b/android/CouchbaseLite/src/main/java/com/couchbase/lite/DatabaseConfiguration.java
@@ -1,0 +1,29 @@
+package com.couchbase.lite;
+
+import android.content.Context;
+
+public class DatabaseConfiguration extends BaseDatabaseConfiguration{
+    private Context context;
+
+    public DatabaseConfiguration() {
+    }
+
+    public DatabaseConfiguration(Context context) {
+        this.context = context;
+        setDirectory(context.getFilesDir());
+        setConflictResolver(null);
+    }
+
+    //---------------------------------------------
+    // Package level access
+    //---------------------------------------------
+
+    /* package */ DatabaseConfiguration copy() {
+        DatabaseConfiguration config =  new DatabaseConfiguration();
+        config.context = this.context;
+        config.setConflictResolver(this.getConflictResolver());
+        config.setDirectory(this.getDirectory());
+        config.setEncryptionKey(this.getEncryptionKey());
+        return config;
+    }
+}

--- a/shared/src/main/java/com/couchbase/lite/Array.java
+++ b/shared/src/main/java/com/couchbase/lite/Array.java
@@ -6,6 +6,7 @@ import com.couchbase.litecore.fleece.FLEncoder;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -325,6 +326,14 @@ public class Array extends ReadOnlyArray implements ArrayInterface, ObjectChange
             }
         }
         return array;
+    }
+    //---------------------------------------------
+    // Iterable implementation
+    //---------------------------------------------
+
+    @Override
+    public Iterator<Object> iterator() {
+        return list != null ? list.iterator() : super.iterator();
     }
 
     //---------------------------------------------

--- a/shared/src/main/java/com/couchbase/lite/BaseDatabaseConfiguration.java
+++ b/shared/src/main/java/com/couchbase/lite/BaseDatabaseConfiguration.java
@@ -18,7 +18,7 @@ import java.io.File;
 /**
  * Options for opening a database. All properties default to false or null.
  */
-public final class DatabaseConfiguration {
+public class BaseDatabaseConfiguration {
     //---------------------------------------------
     // member variables
     //---------------------------------------------
@@ -33,10 +33,10 @@ public final class DatabaseConfiguration {
     /**
      * Constructs a new DatabaseConfiguration with default values.
      */
-    public DatabaseConfiguration() {
+    /*package*/ BaseDatabaseConfiguration() {
     }
 
-    public DatabaseConfiguration(File directory, Object encryptionKey, ConflictResolver conflictResolver) {
+    /*package*/ BaseDatabaseConfiguration(File directory, Object encryptionKey, ConflictResolver conflictResolver) {
         this.directory = directory;
         this.encryptionKey = encryptionKey;
         this.conflictResolver = conflictResolver;
@@ -60,8 +60,9 @@ public final class DatabaseConfiguration {
      *
      * @param directory the directory
      */
-    public void setDirectory(File directory) {
+    public BaseDatabaseConfiguration setDirectory(File directory) {
         this.directory = directory;
+        return this;
     }
 
     /**
@@ -79,23 +80,25 @@ public final class DatabaseConfiguration {
      *
      * @param encryptionKey the key
      */
-    public void setEncryptionKey(Object encryptionKey) {
+    public BaseDatabaseConfiguration setEncryptionKey(Object encryptionKey) {
         this.encryptionKey = encryptionKey;
+        return this;
     }
 
     public ConflictResolver getConflictResolver() {
         return conflictResolver;
     }
 
-    public void setConflictResolver(ConflictResolver conflictResolver) {
+    public BaseDatabaseConfiguration setConflictResolver(ConflictResolver conflictResolver) {
         this.conflictResolver = conflictResolver;
+        return this;
     }
 
     //---------------------------------------------
     // Package level access
     //---------------------------------------------
 
-    /* package */ DatabaseConfiguration copy() {
-        return new DatabaseConfiguration(this.directory, this.encryptionKey, this.conflictResolver);
+    /* package */ BaseDatabaseConfiguration copy() {
+        return new BaseDatabaseConfiguration(this.directory, this.encryptionKey, this.conflictResolver);
     }
 }

--- a/shared/src/main/java/com/couchbase/lite/BaseDatabaseConfiguration.java
+++ b/shared/src/main/java/com/couchbase/lite/BaseDatabaseConfiguration.java
@@ -30,18 +30,6 @@ public class BaseDatabaseConfiguration {
     // Constructors
     //---------------------------------------------
 
-    /**
-     * Constructs a new DatabaseConfiguration with default values.
-     */
-    /*package*/ BaseDatabaseConfiguration() {
-    }
-
-    /*package*/ BaseDatabaseConfiguration(File directory, Object encryptionKey, ConflictResolver conflictResolver) {
-        this.directory = directory;
-        this.encryptionKey = encryptionKey;
-        this.conflictResolver = conflictResolver;
-    }
-
     //---------------------------------------------
     // API - public methods
     //---------------------------------------------
@@ -97,8 +85,4 @@ public class BaseDatabaseConfiguration {
     //---------------------------------------------
     // Package level access
     //---------------------------------------------
-
-    /* package */ BaseDatabaseConfiguration copy() {
-        return new BaseDatabaseConfiguration(this.directory, this.encryptionKey, this.conflictResolver);
-    }
 }

--- a/shared/src/main/java/com/couchbase/lite/Database.java
+++ b/shared/src/main/java/com/couchbase/lite/Database.java
@@ -90,17 +90,6 @@ public final class Database {
     //---------------------------------------------
 
     /**
-     * Construct a Database with a given name and the default database config.
-     * If the database does not yet exist, it will be created.
-     *
-     * @param name The name of the database. May NOT contain capital letters!
-     * @throws CouchbaseLiteException Throws an exception if any error occurs during the operation.
-     */
-    public Database(String name) throws CouchbaseLiteException {
-        throw new UnsupportedOperationException();
-    }
-
-    /**
      * Construct a  Database with a given name and database config.
      * If the database does not yet exist, it will be created, unless the `readOnly` option is used.
      *

--- a/shared/src/main/java/com/couchbase/lite/Dictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/Dictionary.java
@@ -399,7 +399,7 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
      */
     @Override
     public boolean contains(String key) {
-        Object value = map.get(key);
+        Object value = map != null ? map.get(key) : null;
         if (value == null)
             return super.contains(key);
         else

--- a/shared/src/main/java/com/couchbase/lite/Dictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/Dictionary.java
@@ -13,7 +13,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.TreeMap;
 
 import static com.couchbase.lite.internal.support.ClassUtils.cast;
 import static com.couchbase.lite.internal.support.ClassUtils.toDouble;
@@ -368,7 +367,7 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
      */
     @Override
     public Map<String, Object> toMap() {
-        Map<String, Object> result = map != null ? new TreeMap<>(map) : new TreeMap<String, Object>();
+        Map<String, Object> result = map != null ? new HashMap<>(map) : new HashMap<String, Object>();
 
         // Backing data:
         Map<String, Object> backingData = super.toMap();

--- a/shared/src/main/java/com/couchbase/lite/Dictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/Dictionary.java
@@ -12,6 +12,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 
 import static com.couchbase.lite.internal.support.ClassUtils.cast;
 import static com.couchbase.lite.internal.support.ClassUtils.toDouble;
@@ -365,7 +366,7 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
      */
     @Override
     public Map<String, Object> toMap() {
-        Map<String, Object> result = map != null ? new HashMap<>(map) : new HashMap<String, Object>();
+        Map<String, Object> result = map != null ? new TreeMap<>(map) : new TreeMap<String, Object>();
 
         // Backing data:
         Map<String, Object> backingData = super.toMap();

--- a/shared/src/main/java/com/couchbase/lite/Dictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/Dictionary.java
@@ -103,9 +103,9 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
     @Override
     public List<String> getKeys() {
         if (!changed)
-            return super.getKeys();
+            return new ArrayList(super.getKeys());
         else
-            return allKeys();
+            return new ArrayList(allKeys());
     }
 
     /**

--- a/shared/src/main/java/com/couchbase/lite/Dictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/Dictionary.java
@@ -103,7 +103,8 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
     @Override
     public List<String> getKeys() {
         if (!changed)
-            return new ArrayList(super.getKeys());
+            // NOTE: super.getKeys() already creates copy of List.
+            return super.getKeys();
         else
             return new ArrayList(allKeys());
     }

--- a/shared/src/main/java/com/couchbase/lite/Document.java
+++ b/shared/src/main/java/com/couchbase/lite/Document.java
@@ -191,6 +191,11 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
         return dictionary.count();
     }
 
+    @Override
+    public List<String> getKeys() {
+        return dictionary.getKeys();
+    }
+
     /**
      * Gets a property's value as an object. The object types are Blob, Array,
      * Dictionary, Number, or String based on the underlying data type; or nil if the
@@ -341,14 +346,10 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
         return dictionary.contains(key);
     }
 
+
     //---------------------------------------------
     // Package level access
     //---------------------------------------------
-
-    @Override
-    /*package*/ List<String> allKeys() {
-        return dictionary.allKeys();
-    }
 
     /*package*/  Database getDatabase() {
         return database;
@@ -386,6 +387,11 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
 
         // reset
         setC4Doc(null);
+    }
+
+    @Override
+    /*package*/ boolean isEmpty() {
+        return dictionary.isEmpty();
     }
 
     //---------------------------------------------
@@ -596,11 +602,6 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
         return dictionary.isChanged();
     }
 
-    private boolean isEmpty() {
-        return dictionary.isEmpty();
-    }
-
-
     // The next four functions search recursively for a property "_cbltype":"blob".
 
     private static boolean objectContainsBlob(Object obj) {
@@ -629,7 +630,7 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
         if (dict == null)
             return false;
         boolean containsBlob = false;
-        for (String key : dict.allKeys()) {
+        for (String key : dict.getKeys()) {
             if (containsBlob = objectContainsBlob(dict.getObject(key)))
                 break;
         }
@@ -640,7 +641,7 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
         if (doc == null)
             return false;
         boolean containsBlob = false;
-        for (String key : doc.allKeys()) {
+        for (String key : doc.getKeys()) {
             if (containsBlob = objectContainsBlob(doc.getObject(key)))
                 break;
         }

--- a/shared/src/main/java/com/couchbase/lite/Query.java
+++ b/shared/src/main/java/com/couchbase/lite/Query.java
@@ -33,19 +33,21 @@ import java.util.Map;
 public class Query {
     private static final String LOG_TAG = Log.QUERY;
 
+    //---------------------------------------------
+    // member variables
+    //---------------------------------------------
+
     private Database database;
-
     private C4Query c4query;
-
     private Select select;
-
     private DataSource from;
-
     private Expression where;
-
     private OrderBy orderBy;
-
     private boolean distinct;
+
+    //---------------------------------------------
+    // API - public methods
+    //---------------------------------------------
 
     /**
      * Create a SELECT ALL (*) query. You can then call the Select object's methods such as
@@ -90,6 +92,30 @@ public class Query {
             throw LiteCoreBridge.convertException(e);
         }
     }
+
+    /**
+     * Returns a string describing the implementation of the compiled query.
+     * This is intended to be read by a developer for purposes of optimizing the query, especially
+     * to add database indexes. It's not machine-readable and its format may change.
+     * As currently implemented, the result is two or more lines separated by newline characters:
+     * * The first line is the SQLite SELECT statement.
+     * * The subsequent lines are the output of SQLite's "EXPLAIN QUERY PLAN" command applied to that
+     * statement; for help interpreting this, see https://www.sqlite.org/eqp.html . The most
+     * important thing to know is that if you see "SCAN TABLE", it means that SQLite is doing a
+     * slow linear scan of the documents instead of using an index.
+     *
+     * @return a string describing the implementation of the compiled query.
+     * @throws CouchbaseLiteException if an error occurs
+     */
+    public String explain() throws CouchbaseLiteException {
+        if (c4query == null)
+            check();
+        return c4query.explain();
+    }
+
+    //---------------------------------------------
+    // Protected level access
+    //---------------------------------------------
 
     protected Select getSelect() {
         return select;
@@ -139,6 +165,10 @@ public class Query {
         this.distinct = query.distinct;
     }
 
+    //---------------------------------------------
+    // Package level access
+    //---------------------------------------------
+
     /* package */ Database getDatabase() {
         return database;
     }
@@ -146,6 +176,10 @@ public class Query {
     /* package */ C4Query getC4Query() {
         return c4query;
     }
+
+    //---------------------------------------------
+    // Private (in class only)
+    //---------------------------------------------
 
     private void check() throws CouchbaseLiteException {
         database = (Database) from.getSource();
@@ -179,5 +213,4 @@ public class Query {
             json.put("ORDER_BY", orderBy.asJSON());
         return json;
     }
-
 }

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyArray.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyArray.java
@@ -88,7 +88,7 @@ public class ReadOnlyArray implements ReadOnlyArrayInterface, FleeceEncodable {
      */
     @Override
     public int getInt(int index) {
-        return fleeceValue(index).asInt();
+        return (int)fleeceValue(index).asInt();
     }
 
     /**

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionary.java
@@ -55,7 +55,7 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
 
     @Override
     public List<String> getKeys() {
-        return fleeceKeys();
+        return new ArrayList(fleeceKeys());
     }
 
     /**

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionary.java
@@ -104,7 +104,7 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
     @Override
     public int getInt(String key) {
         FLValue value = fleeceValue(key);
-        return value != null ? value.asInt() : 0;
+        return value != null ? (int)value.asInt() : 0;
     }
 
     /**

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionary.java
@@ -53,6 +53,11 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
         return flDict != null ? (int) flDict.count() : 0;
     }
 
+    @Override
+    public List<String> getKeys() {
+        return fleeceKeys();
+    }
+
     /**
      * Gets a property's value as an object. The object types are Blob, Array,
      * Dictionary, Number, or String based on the underlying data type; or nil if the
@@ -262,25 +267,6 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
     // Package level access
     //---------------------------------------------
 
-    /*package*/ List<String> allKeys() {
-        if (keys == null) {
-            List<String> results = new ArrayList<>();
-            if (flDict != null) {
-                FLDictIterator itr = new FLDictIterator();
-                itr.begin(flDict);
-                String key;
-                while ((key = SharedKeys.getKey(itr, this.sharedKeys)) != null) {
-                    results.add(key);
-                    itr.next();
-                }
-                itr.free();
-            }
-
-            keys = results;
-        }
-        return keys;
-    }
-
     // FleeceEncodable implementation
     @Override
     public void fleeceEncode(FLEncoder encoder, Database database) throws CouchbaseLiteException {
@@ -292,9 +278,15 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
     //---------------------------------------------
     @Override
     public Iterator<String> iterator() {
-        return allKeys().iterator();
+        return getKeys().iterator();
     }
 
+    //---------------------------------------------
+    // Package
+    //---------------------------------------------
+    /* package */boolean isEmpty() {
+        return count() == 0;
+    }
     //---------------------------------------------
     // Private (in class only)
     //---------------------------------------------
@@ -327,5 +319,24 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
         itr.free();
 
         return dict;
+    }
+
+    private List<String> fleeceKeys() {
+        if (keys == null) {
+            List<String> results = new ArrayList<>();
+            if (flDict != null) {
+                FLDictIterator itr = new FLDictIterator();
+                itr.begin(flDict);
+                String key;
+                while ((key = SharedKeys.getKey(itr, this.sharedKeys)) != null) {
+                    results.add(key);
+                    itr.next();
+                }
+                itr.free();
+            }
+
+            keys = results;
+        }
+        return keys;
     }
 }

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionaryInterface.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionaryInterface.java
@@ -1,10 +1,13 @@
 package com.couchbase.lite;
 
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 /* package */ interface ReadOnlyDictionaryInterface extends Iterable<String> {
     int count();
+
+    List<String> getKeys();
 
     Object getObject(String key);
 

--- a/shared/src/main/java/com/couchbase/lite/SharedKeys.java
+++ b/shared/src/main/java/com/couchbase/lite/SharedKeys.java
@@ -71,7 +71,7 @@ public class SharedKeys implements FLValue.ISharedKeys {
             return null;
 
         if (key.isInteger())
-            return getKey(key.asInt());
+            return getKey((int)key.asInt());
 
         return (String) valueToObject(key);
     }


### PR DESCRIPTION
#1174 - 2.0: API update
  - Implemented DatabaseConfiguration(Context) for Android
  - Implemented Dictionary.getKeys() instead of getAllKeys()
  - Removed Database(String) consturctor which is inrelebant for Android.
  - Implemented Query.explain()
  - Ported two Unit Test cses for Document Change Listener
  - Ported testRemoveDictionary() unit test. And also fixed the bug which was found by the test

#1158 - 2.0: getLong/setLong does not work as expected
  - Casting to int from long cause data loss. Fixed this.

#1160 - 2.0: Double/Float without decimal are returned as Integer
  - Fleece stores double or float value without decimal fraction as the integer value. Fixed the test cases

#1161 - 2.0: Double value which is stored in fleece is returned as Float.
  - Fleece stores the double value, which is same as the float value, as the float value. Fixed the test cases

#1170 - Array and Dictionary should throw ConcurrentModificationException if Array or Dictionary is modified.
 - Check Array/Dictionary updates during iteration.

Note: For details, please refer each commit?
