### PR TITLE
Fixed #1188 - 2.0: Review failing DocumentTest unit tests

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
@@ -159,9 +159,9 @@ public class ArrayTest extends BaseTest {
                 assertEquals(true, a.getObject(0));
                 assertEquals(false, a.getObject(1));
                 assertEquals("string", a.getObject(2));
-                assertEquals(0, ((Number)a.getObject(3)).intValue());
-                assertEquals(1, ((Number)a.getObject(4)).intValue());
-                assertEquals(-1, ((Number)a.getObject(5)).intValue());
+                assertEquals(0, ((Number) a.getObject(3)).intValue());
+                assertEquals(1, ((Number) a.getObject(4)).intValue());
+                assertEquals(-1, ((Number) a.getObject(5)).intValue());
                 assertEquals(1.1, a.getObject(6));
                 assertEquals(kArrayTestDate, a.getObject(7));
                 assertEquals(null, a.getObject(8));
@@ -215,9 +215,9 @@ public class ArrayTest extends BaseTest {
                 assertEquals(true, a.getObject(12 + 0));
                 assertEquals(false, a.getObject(12 + 1));
                 assertEquals("string", a.getObject(12 + 2));
-                assertEquals(0, ((Number)a.getObject(12 + 3)).intValue());
-                assertEquals(1, ((Number)a.getObject(12 + 4)).intValue());
-                assertEquals(-1, ((Number)a.getObject(12 + 5)).intValue());
+                assertEquals(0, ((Number) a.getObject(12 + 3)).intValue());
+                assertEquals(1, ((Number) a.getObject(12 + 4)).intValue());
+                assertEquals(-1, ((Number) a.getObject(12 + 5)).intValue());
                 assertEquals(1.1, a.getObject(12 + 6));
                 assertEquals(kArrayTestDate, a.getObject(12 + 7));
                 assertEquals(null, a.getObject(12 + 8));
@@ -266,9 +266,9 @@ public class ArrayTest extends BaseTest {
                 assertEquals(true, a.getObject(0));
                 assertEquals(false, a.getObject(1));
                 assertEquals("string", a.getObject(2));
-                assertEquals(0, ((Number)a.getObject(3)).intValue());
-                assertEquals(1, ((Number)a.getObject(4)).intValue());
-                assertEquals(-1, ((Number)a.getObject(5)).intValue());
+                assertEquals(0, ((Number) a.getObject(3)).intValue());
+                assertEquals(1, ((Number) a.getObject(4)).intValue());
+                assertEquals(-1, ((Number) a.getObject(5)).intValue());
                 assertEquals(1.1, a.getObject(6));
                 assertEquals(kArrayTestDate, a.getObject(7));
                 assertEquals(null, a.getObject(8));
@@ -523,12 +523,12 @@ public class ArrayTest extends BaseTest {
         save(doc, "array", array, new Validator<Array>() {
             @Override
             public void validate(Array a) {
-                assertNull(a.getNumber(0));
-                assertNull(a.getNumber(1));
+                assertEquals(1, a.getNumber(0).intValue());
+                assertEquals(0, a.getNumber(1).intValue());
                 assertNull(a.getNumber(2));
-                assertEquals(0, ((Number)a.getNumber(3)).intValue());
-                assertEquals(1, ((Number)a.getNumber(4)).intValue());
-                assertEquals(-1, ((Number)a.getNumber(5)).intValue());
+                assertEquals(0, a.getNumber(3).intValue());
+                assertEquals(1, a.getNumber(4).intValue());
+                assertEquals(-1, a.getNumber(5).intValue());
                 assertEquals(1.1, a.getNumber(6));
                 assertNull(a.getNumber(7));
                 assertNull(a.getNumber(8));
@@ -549,7 +549,7 @@ public class ArrayTest extends BaseTest {
         save(doc, "array", array, new Validator<Array>() {
             @Override
             public void validate(Array a) {
-                assertEquals(0, a.getInt(0));
+                assertEquals(1, a.getInt(0));
                 assertEquals(0, a.getInt(1));
                 assertEquals(0, a.getInt(2));
                 assertEquals(0, a.getInt(3));
@@ -575,7 +575,7 @@ public class ArrayTest extends BaseTest {
         save(doc, "array", array, new Validator<Array>() {
             @Override
             public void validate(Array a) {
-                assertEquals(0, a.getLong(0));
+                assertEquals(1, a.getLong(0));
                 assertEquals(0, a.getLong(1));
                 assertEquals(0, a.getLong(2));
                 assertEquals(0, a.getLong(3));
@@ -601,7 +601,7 @@ public class ArrayTest extends BaseTest {
         save(doc, "array", array, new Validator<Array>() {
             @Override
             public void validate(Array a) {
-                assertEquals(0.0f, a.getFloat(0), 0.0f);
+                assertEquals(1.0f, a.getFloat(0), 0.0f);
                 assertEquals(0.0f, a.getFloat(1), 0.0f);
                 assertEquals(0.0f, a.getFloat(2), 0.0f);
                 assertEquals(0.0f, a.getFloat(3), 0.0f);
@@ -627,7 +627,7 @@ public class ArrayTest extends BaseTest {
         save(doc, "array", array, new Validator<Array>() {
             @Override
             public void validate(Array a) {
-                assertEquals(0.0, a.getDouble(0), 0.0);
+                assertEquals(1.0, a.getDouble(0), 0.0);
                 assertEquals(0.0, a.getDouble(1), 0.0);
                 assertEquals(0.0, a.getDouble(2), 0.0);
                 assertEquals(0.0, a.getDouble(3), 0.0);
@@ -661,8 +661,8 @@ public class ArrayTest extends BaseTest {
             public void validate(Array a) {
                 assertEquals(Integer.MIN_VALUE, a.getNumber(0).intValue());
                 assertEquals(Integer.MAX_VALUE, a.getNumber(1).intValue());
-                assertEquals(Integer.MIN_VALUE, ((Number)a.getObject(0)).intValue());
-                assertEquals(Integer.MAX_VALUE, ((Number)a.getObject(1)).intValue());
+                assertEquals(Integer.MIN_VALUE, ((Number) a.getObject(0)).intValue());
+                assertEquals(Integer.MAX_VALUE, ((Number) a.getObject(1)).intValue());
                 assertEquals(Integer.MIN_VALUE, a.getInt(0));
                 assertEquals(Integer.MAX_VALUE, a.getInt(1));
 
@@ -705,7 +705,7 @@ public class ArrayTest extends BaseTest {
             public void validate(Array a) {
                 // NOTE: Number which has no floating part is stored as Integer.
                 //       This causes type difference between before and after storing data into the database.
-                assertEquals(1.00, ((Number)a.getObject(0)).doubleValue(), 0.0);
+                assertEquals(1.00, ((Number) a.getObject(0)).doubleValue(), 0.0);
                 assertEquals(1.00, a.getNumber(0).doubleValue(), 0.0);
                 assertEquals(1, a.getInt(0));
                 assertEquals(1L, a.getLong(0));
@@ -719,7 +719,7 @@ public class ArrayTest extends BaseTest {
                 assertEquals(1.49F, a.getFloat(1), 0.0F);
                 assertEquals(1.49, a.getDouble(1), 0.0);
 
-                assertEquals(1.50, ((Number)a.getObject(2)).doubleValue(), 0.0);
+                assertEquals(1.50, ((Number) a.getObject(2)).doubleValue(), 0.0);
                 assertEquals(1.50, a.getNumber(2).doubleValue(), 0.0);
                 assertEquals(1, a.getInt(2));
                 assertEquals(1L, a.getLong(2));

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
@@ -404,9 +404,9 @@ public class DocumentTest extends BaseTest {
         save(doc, new Validator<Document>() {
             @Override
             public void validate(Document d) {
-                assertEquals(1, ((Number)d.getObject("number1")).intValue());
-                assertEquals(0, ((Number)d.getObject("number2")).intValue());
-                assertEquals(-1, ((Number)d.getObject("number3")).intValue());
+                assertEquals(1, ((Number) d.getObject("number1")).intValue());
+                assertEquals(0, ((Number) d.getObject("number2")).intValue());
+                assertEquals(-1, ((Number) d.getObject("number3")).intValue());
                 assertEquals(1.1, d.getObject("number4"));
             }
         });
@@ -421,10 +421,10 @@ public class DocumentTest extends BaseTest {
         save(doc, new Validator<Document>() {
             @Override
             public void validate(Document d) {
-                assertEquals(0, ((Number)d.getObject("number1")).intValue());
-                assertEquals(1, ((Number)d.getObject("number2")).intValue());
+                assertEquals(0, ((Number) d.getObject("number1")).intValue());
+                assertEquals(1, ((Number) d.getObject("number2")).intValue());
                 assertEquals(1.1, d.getObject("number3"));
-                assertEquals(-1, ((Number)d.getObject("number4")).intValue());
+                assertEquals(-1, ((Number) d.getObject("number4")).intValue());
             }
         });
     }
@@ -437,8 +437,8 @@ public class DocumentTest extends BaseTest {
             @Override
             public void validate(final Document d) {
                 assertNull(d.getNumber("null"));
-                assertNull(d.getNumber("true"));
-                assertNull(d.getNumber("false"));
+                assertEquals(1, d.getNumber("true").intValue());
+                assertEquals(0, d.getNumber("false").intValue());
                 assertNull(d.getNumber("string"));
                 assertEquals(0, d.getNumber("zero").intValue());
                 assertEquals(1, d.getNumber("one").intValue());
@@ -461,8 +461,7 @@ public class DocumentTest extends BaseTest {
             @Override
             public void validate(final Document d) {
                 assertEquals(0, d.getInt("null"));
-                //TODO
-                //assertEquals(1, d.getInt("true"));
+                assertEquals(1, d.getInt("true"));
                 assertEquals(0, d.getInt("false"));
                 assertEquals(0, d.getInt("string"));
                 assertEquals(0, d.getInt("zero"));
@@ -486,8 +485,7 @@ public class DocumentTest extends BaseTest {
             @Override
             public void validate(final Document d) {
                 assertEquals(0, d.getLong("null"));
-                //TODO
-                //assertEquals(0, d.getLong("true"));
+                assertEquals(1, d.getLong("true"));
                 assertEquals(0, d.getLong("false"));
                 assertEquals(0, d.getLong("string"));
                 assertEquals(0, d.getLong("zero"));
@@ -511,8 +509,7 @@ public class DocumentTest extends BaseTest {
             @Override
             public void validate(final Document d) {
                 assertEquals(0.0f, d.getFloat("null"), 0.0f);
-                //TODO
-                //assertEquals(0.0f, d.getFloat("true"), 0.0f);
+                assertEquals(1.0f, d.getFloat("true"), 0.0f);
                 assertEquals(0.0f, d.getFloat("false"), 0.0f);
                 assertEquals(0.0f, d.getFloat("string"), 0.0f);
                 assertEquals(0.0f, d.getFloat("zero"), 0.0f);
@@ -536,8 +533,7 @@ public class DocumentTest extends BaseTest {
             @Override
             public void validate(final Document d) {
                 assertEquals(0.0, d.getDouble("null"), 0.0);
-                //TODO
-                //assertEquals(0.0, d.getDouble("true"), 0.0);
+                assertEquals(1.0, d.getDouble("true"), 0.0);
                 assertEquals(0.0, d.getDouble("false"), 0.0);
                 assertEquals(0.0, d.getDouble("string"), 0.0);
                 assertEquals(0.0, d.getDouble("zero"), 0.0);
@@ -571,8 +567,8 @@ public class DocumentTest extends BaseTest {
             public void validate(Document doc) {
                 assertEquals(Integer.MIN_VALUE, doc.getNumber("min_int").intValue());
                 assertEquals(Integer.MAX_VALUE, doc.getNumber("max_int").intValue());
-                assertEquals(Integer.MIN_VALUE, ((Number)doc.getObject("min_int")).intValue());
-                assertEquals(Integer.MAX_VALUE, ((Number)doc.getObject("max_int")).intValue());
+                assertEquals(Integer.MIN_VALUE, ((Number) doc.getObject("min_int")).intValue());
+                assertEquals(Integer.MAX_VALUE, ((Number) doc.getObject("max_int")).intValue());
                 assertEquals(Integer.MIN_VALUE, doc.getInt("min_int"));
                 assertEquals(Integer.MAX_VALUE, doc.getInt("max_int"));
 
@@ -614,38 +610,39 @@ public class DocumentTest extends BaseTest {
         save(doc, new Validator<Document>() {
             @Override
             public void validate(Document doc) {
-                // TODO
-                //assertEquals(1.00, doc.getObject("number1"));  // return 1
-                //assertEquals(1.00, doc.getNumber("number1"));  // return 1
+                assertEquals(1.00, ((Number) doc.getObject("number1")).doubleValue(), 0.0);
+                assertEquals(1.00, doc.getNumber("number1").doubleValue(), 0.0);
                 assertEquals(1, doc.getInt("number1"));
                 assertEquals(1L, doc.getLong("number1"));
                 assertEquals(1.00F, doc.getFloat("number1"), 0.0F);
                 assertEquals(1.00, doc.getDouble("number1"), 0.0);
 
-                //assertEquals(1.49, doc.getObject("number2"));  // return 1
-                //assertEquals(1.49, doc.getNumber("number2"));  // return 1
+                assertEquals(1.49, ((Number) doc.getObject("number2")).doubleValue(), 0.0);
+                assertEquals(1.49, doc.getNumber("number2").doubleValue(), 0.0);
                 assertEquals(1, doc.getInt("number2"));
                 assertEquals(1L, doc.getLong("number2"));
                 assertEquals(1.49F, doc.getFloat("number2"), 0.0F);
                 assertEquals(1.49, doc.getDouble("number2"), 0.0);
 
-                //assertEquals(1.50, doc.getObject("number3"));  // return 1
-                //assertEquals(1.50, doc.getNumber("number3"));  // return 1
-                // TODO: lite core bug
+                assertEquals(1.50, ((Number) doc.getObject("number3")).doubleValue(), 0.0);
+                assertEquals(1.50, doc.getNumber("number3").doubleValue(), 0.0);
+                // TODO: https://github.com/couchbaselabs/fleece/pull/19
                 //assertEquals(1, doc.getInt("number3"));
                 //assertEquals(1L, doc.getLong("number3"));
                 assertEquals(1.50F, doc.getFloat("number3"), 0.0F);
                 assertEquals(1.50, doc.getDouble("number3"), 0.0);
 
-                //assertEquals(1.51, doc.getObject("number4"));  // return 1
-                //assertEquals(1.51, doc.getNumber("number4"));  // return 1
+                assertEquals(1.51, ((Number) doc.getObject("number4")).doubleValue(), 0.0);
+                assertEquals(1.51, doc.getNumber("number4").doubleValue(), 0.0);
+                // TODO: https://github.com/couchbaselabs/fleece/pull/19
                 //assertEquals(1, doc.getInt("number4"));
                 //assertEquals(1L, doc.getLong("number4"));
                 assertEquals(1.51F, doc.getFloat("number4"), 0.0F);
                 assertEquals(1.51, doc.getDouble("number4"), 0.0);
 
-                //assertEquals(1.99, doc.getObject("number5"));  // return 1
-                //assertEquals(1.99, doc.getNumber("number5"));  // return 1
+                assertEquals(1.99, ((Number) doc.getObject("number5")).doubleValue(), 0.0);  // return 1
+                assertEquals(1.99, doc.getNumber("number5").doubleValue(), 0.0);  // return 1
+                // TODO: https://github.com/couchbaselabs/fleece/pull/19
                 //assertEquals(1, doc.getInt("number5"));
                 //assertEquals(1L, doc.getLong("number5"));
                 assertEquals(1.99F, doc.getFloat("number5"), 0.0F);
@@ -771,9 +768,7 @@ public class DocumentTest extends BaseTest {
         });
     }
 
-
-    // TODO: Android API 16 - assertEquals(Map.toString(), Map.toString()): order is not guranteed! Need to work!!!!
-    // @Test
+    @Test
     public void testSetBlob() {
         Document doc = createDocument("doc1");
 

--- a/shared/src/main/java/com/couchbase/lite/Array.java
+++ b/shared/src/main/java/com/couchbase/lite/Array.java
@@ -88,7 +88,6 @@ public class Array extends ReadOnlyArray implements ArrayInterface, ObjectChange
     @Override
     public Array set(int index, Object value) {
         Object oldValue = getObject(index);
-        //if ((value != null && !value.equals(oldValue)) || (value == null && oldValue != null)) {
         if ((value != null && !value.equals(oldValue)) || value == null) {
             value = CBLData.convert(value, this);
             detachChangeListenerForObject(oldValue);
@@ -209,7 +208,12 @@ public class Array extends ReadOnlyArray implements ArrayInterface, ObjectChange
      */
     @Override
     public Number getNumber(int index) {
-        return cast(getObject(index), Number.class);
+        Object value = getObject(index);
+        // special handling for Boolean
+        if (value != null && value instanceof Boolean)
+            return new Integer(value == Boolean.TRUE ? 1 : 0);
+        else
+            return cast(value, Number.class);
     }
 
     /**

--- a/shared/src/main/java/com/couchbase/lite/Dictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/Dictionary.java
@@ -30,7 +30,7 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
     private Map<String, Object> map = null;
     private Map<ObjectChangeListener, Integer> changeListeners = new HashMap<>();
     private boolean changed = false;
-    private int     changedCount = 0;
+    private int changedCount = 0;
     private List<String> keys = null; // dictionary key cache
 
     //---------------------------------------------
@@ -237,7 +237,12 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
      */
     @Override
     public Number getNumber(String key) {
-        return cast(getObject(key), Number.class);
+        Object value = getObject(key);
+        // special handling for Boolean
+        if (value != null && value instanceof Boolean)
+            return new Integer(value == Boolean.TRUE ? 1 : 0);
+        else
+            return cast(value, Number.class);
     }
 
     /**

--- a/shared/src/main/java/com/couchbase/lite/internal/support/ClassUtils.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/support/ClassUtils.java
@@ -10,6 +10,8 @@ public class ClassUtils {
     public static int toInt(Object value, int defaultValue) {
         if (value instanceof Number)
             return ((Number) value).intValue();
+        else if (value instanceof Boolean)
+            return value == Boolean.TRUE ? 1 : 0;
         else
             return defaultValue;
     }
@@ -17,6 +19,8 @@ public class ClassUtils {
     public static long toLong(Object value, long defaultValue) {
         if (value instanceof Number)
             return ((Number) value).longValue();
+        else if (value instanceof Boolean)
+            return value == Boolean.TRUE ? 1L : 0L;
         else
             return defaultValue;
     }
@@ -24,6 +28,8 @@ public class ClassUtils {
     public static float toFloat(Object value, float defaultValue) {
         if (value instanceof Number)
             return ((Number) value).floatValue();
+        else if (value instanceof Boolean)
+            return value == Boolean.TRUE ? 1.0F : 0.0F;
         else
             return defaultValue;
     }
@@ -31,6 +37,8 @@ public class ClassUtils {
     public static double toDouble(Object value, double defaultValue) {
         if (value instanceof Number)
             return ((Number) value).doubleValue();
+        else if (value instanceof Boolean)
+            return value == Boolean.TRUE ? 1.0 : 0.0;
         else
             return defaultValue;
     }


### PR DESCRIPTION
- Fixed Array.getInt()/getLong()/getFloat()/getDouble()/getNumber() return value for the stored Boolean value.
- Also fixed corresponding unit test cases.
- Fixed Dictionary.getInt()/getLong()/getFloat()/getDouble()/getNumber() return value for the stored Boolean value.
- Also fixed corresponding unit test cases.