### PR TITLE
Fixed #1187 - 2.0: Review failing DatabaseTest unit tests

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConflictTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConflictTest.java
@@ -94,11 +94,11 @@ public class ConflictTest extends BaseTest {
             @Override
             public void run() {
                 try {
-                    com.couchbase.litecore.Document trickey = db.internal().getDocument(docID, true);
-                    FLEncoder enc = db.internal().createFleeceEncoder();
+                    com.couchbase.litecore.Document trickey = db.getC4Database().getDocument(docID, true);
+                    FLEncoder enc = db.getC4Database().createFleeceEncoder();
                     enc.writeValue(props);
                     byte[] bytes = enc.finish();
-                    com.couchbase.litecore.Document newDoc = db.internal().put(
+                    com.couchbase.litecore.Document newDoc = db.getC4Database().put(
                             docID,
                             bytes,
                             false,

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -376,9 +376,8 @@ public class DatabaseTest extends BaseTest {
         try {
             Document doc = db.getDocument("doc1");
             fail();
-        } catch (CouchbaseLiteException ex) {
-            assertEquals(Status.CBLErrorDomain, ex.getDomain());
-            assertEquals(Status.DBClosed, ex.getCode());
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -392,9 +391,8 @@ public class DatabaseTest extends BaseTest {
         try {
             Document doc = db.getDocument("doc1");
             fail();
-        } catch (CouchbaseLiteException ex) {
-            assertEquals(Status.CBLErrorDomain, ex.getDomain());
-            assertEquals(Status.DBClosed, ex.getCode());
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -525,9 +523,8 @@ public class DatabaseTest extends BaseTest {
         try {
             save(doc);
             fail();
-        } catch (CouchbaseLiteException e) {
-            assertEquals(Status.CBLErrorDomain, e.getDomain());
-            assertEquals(Status.DBClosed, e.getCode());
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -542,9 +539,8 @@ public class DatabaseTest extends BaseTest {
         try {
             save(doc);
             fail();
-        } catch (CouchbaseLiteException e) {
-            assertEquals(Status.CBLErrorDomain, e.getDomain());
-            assertEquals(Status.DBClosed, e.getCode());
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -687,9 +683,8 @@ public class DatabaseTest extends BaseTest {
         try {
             db.delete(doc);
             fail();
-        } catch (CouchbaseLiteException e) {
-            assertEquals(Status.CBLErrorDomain, e.getDomain());
-            assertEquals(Status.DBClosed, e.getCode());
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -705,9 +700,8 @@ public class DatabaseTest extends BaseTest {
         try {
             db.delete(doc);
             fail();
-        } catch (CouchbaseLiteException e) {
-            assertEquals(Status.CBLErrorDomain, e.getDomain());
-            assertEquals(Status.DBClosed, e.getCode());
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -843,9 +837,8 @@ public class DatabaseTest extends BaseTest {
         try {
             db.purge(doc);
             fail();
-        } catch (CouchbaseLiteException e) {
-            assertEquals(Status.CBLErrorDomain, e.getDomain());
-            assertEquals(Status.DBClosed, e.getCode());
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -861,9 +854,8 @@ public class DatabaseTest extends BaseTest {
         try {
             db.purge(doc);
             fail();
-        } catch (CouchbaseLiteException e) {
-            assertEquals(Status.CBLErrorDomain, e.getDomain());
-            assertEquals(Status.DBClosed, e.getCode());
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 

--- a/shared/src/main/java/com/couchbase/lite/Blob.java
+++ b/shared/src/main/java/com/couchbase/lite/Blob.java
@@ -320,7 +320,7 @@ public final class Blob implements FleeceEncodable {
         C4BlobKey key = null;
         try {
             // TODO: https://github.com/couchbase/couchbase-lite-android/issues/1136
-            // C4BlobStore store = database.internal().getBlobStore();
+            // C4BlobStore store = database.getC4Database().getBlobStore();
             C4BlobStore store = getBlobStore(db);
             try {
                 if (content != null) {
@@ -397,7 +397,7 @@ public final class Blob implements FleeceEncodable {
             File attachments = new File(database.getPath(), "Attachments");
             return C4BlobStore.open(attachments.getPath(), kC4DB_Create);
             // TODO: https://github.com/couchbase/couchbase-lite-android/issues/1136
-            // return database.internal().getBlobStore();
+            // return database.getC4Database().getBlobStore();
         } catch (LiteCoreException e) {
             Log.w(TAG, "Failed to get BlobStore instance", e);
             return null;
@@ -414,7 +414,7 @@ public final class Blob implements FleeceEncodable {
             File attachments = new File(db.getPath(), "Attachments");
             return C4BlobStore.open(attachments.getPath(), kC4DB_Create);
             // TODO: https://github.com/couchbase/couchbase-lite-android/issues/1136
-            //return database.internal().getBlobStore();
+            //return database.getC4Database().getBlobStore();
         } catch (LiteCoreException e) {
             Log.w(TAG, "Failed to get BlobStore instance", e);
             return null;

--- a/shared/src/main/java/com/couchbase/lite/CouchbaseLiteException.java
+++ b/shared/src/main/java/com/couchbase/lite/CouchbaseLiteException.java
@@ -103,7 +103,7 @@ public final class CouchbaseLiteException extends RuntimeException {
     public String toString() {
         if (domain > 0 && code > 0)
             return "CouchbaseLiteException{" +
-                    "domain=" + getDomainString() +
+                    "domain=" + domain +
                     ", code=" + code +
                     '}';
         else

--- a/shared/src/main/java/com/couchbase/lite/Database.java
+++ b/shared/src/main/java/com/couchbase/lite/Database.java
@@ -129,7 +129,7 @@ public final class Database {
      * @return the database's path.
      */
     public File getPath() {
-        return c4db != null ? new File(internal().getPath()) : null;
+        return c4db != null ? new File(getC4Database().getPath()) : null;
     }
 
 
@@ -139,7 +139,7 @@ public final class Database {
      * @return the number of documents in the database, -1 if error.
      */
     public int getCount() {
-        return c4db != null ? (int) internal().getDocumentCount() : -1;
+        return c4db != null ? (int) getC4Database().getDocumentCount() : -1;
     }
 
     /**
@@ -222,11 +222,11 @@ public final class Database {
      * @param action the action which is implementation of Runnable interface
      * @throws CouchbaseLiteException Throws an exception if any error occurs during the operation.
      */
-    public void inBatch(Runnable action) throws CouchbaseLiteException {
+    public void inBatch(Runnable action) throws CouchbaseLiteException, IllegalStateException {
         try {
             boolean commit = false;
             Log.e(TAG, "inBatch() beginTransaction()");
-            internal().beginTransaction();
+            getC4Database().beginTransaction();
             try {
                 try {
                     action.run();
@@ -237,7 +237,7 @@ public final class Database {
                     throw new CouchbaseLiteException(e);
                 }
             } finally {
-                internal().endTransaction(commit);
+                getC4Database().endTransaction(commit);
                 Log.e(TAG, "inBatch() endTransaction()");
             }
 
@@ -252,9 +252,9 @@ public final class Database {
     /**
      * Compacts the database file by deleting unused attachment files and vacuuming the SQLite database
      */
-    public void compact() {
+    public void compact() throws CouchbaseLiteException, IllegalStateException {
         try {
-            internal().compact();
+            getC4Database().compact();
         } catch (LiteCoreException e) {
             throw LiteCoreBridge.convertException(e);
         }
@@ -322,7 +322,7 @@ public final class Database {
         if (c4db == null)
             return;
 
-        Log.i(TAG, "Closing %s at path %s", this, internal().getPath());
+        Log.i(TAG, "Closing %s at path %s", this, getC4Database().getPath());
 
         // close db
         closeC4DB();
@@ -426,7 +426,7 @@ public final class Database {
      */
     public void createIndex(List<Expression> expressions,
                             IndexType type,
-                            IndexOptions options) throws CouchbaseLiteException {
+                            IndexOptions options) throws CouchbaseLiteException, IllegalStateException {
         if (expressions == null)
             throw new IllegalArgumentException("expressions parameter cannot be null");
 
@@ -439,7 +439,7 @@ public final class Database {
             String json = JsonUtils.toJson(list).toString();
             String language = options != null ? options.getLanguage() : null;
             boolean ignoreDiacritics = options != null ? options.isIgnoreDiacritics() : false;
-            internal().createIndex(json, type.getValue(), language, ignoreDiacritics);
+            getC4Database().createIndex(json, type.getValue(), language, ignoreDiacritics);
         } catch (JSONException e) {
             throw new CouchbaseLiteException(e);
         } catch (LiteCoreException e) {
@@ -480,23 +480,28 @@ public final class Database {
     }
 
     //////// DATABASES:
-    com.couchbase.litecore.Database internal() throws CouchbaseLiteException {
+
+    /**
+     * @return a reference to C4Database instance if db is open.
+     * @throws IllegalStateException
+     */
+    com.couchbase.litecore.Database getC4Database() throws IllegalStateException {
         if (c4db == null)
-            throw new CouchbaseLiteException(Status.CBLErrorDomain, Status.DBClosed);
+            throw new IllegalStateException("Database is not opened.");
         return c4db;
     }
 
-    /* package */ void beginTransaction() throws CouchbaseLiteException {
+    /* package */ void beginTransaction() throws CouchbaseLiteException, IllegalStateException {
         try {
-            internal().beginTransaction();
+            getC4Database().beginTransaction();
         } catch (LiteCoreException e) {
             throw LiteCoreBridge.convertException(e);
         }
     }
 
-    /* package */ void endTransaction(boolean commit) throws CouchbaseLiteException {
+    /* package */ void endTransaction(boolean commit) throws CouchbaseLiteException, IllegalStateException {
         try {
-            internal().endTransaction(commit);
+            getC4Database().endTransaction(commit);
         } catch (LiteCoreException e) {
             throw LiteCoreBridge.convertException(e);
         }
@@ -507,9 +512,9 @@ public final class Database {
     }
 
     //////// DOCUMENTS:
-    /* package */ com.couchbase.litecore.Document read(String docID, boolean mustExist) throws CouchbaseLiteException {
+    /* package */ com.couchbase.litecore.Document read(String docID, boolean mustExist) throws CouchbaseLiteException, IllegalStateException {
         try {
-            return internal().getDocument(docID, mustExist);
+            return getC4Database().getDocument(docID, mustExist);
         } catch (LiteCoreException e) {
             throw LiteCoreBridge.convertException(e);
         }
@@ -614,25 +619,25 @@ public final class Database {
 
 
     // --- C4Database
-    private void closeC4DB() throws CouchbaseLiteException {
+    private void closeC4DB() throws CouchbaseLiteException, IllegalStateException {
         try {
-            internal().close();
+            getC4Database().close();
         } catch (LiteCoreException e) {
             throw LiteCoreBridge.convertException(e);
         }
     }
 
-    private void deleteC4DB() throws CouchbaseLiteException {
+    private void deleteC4DB() throws CouchbaseLiteException, IllegalStateException {
         try {
-            internal().delete();
+            getC4Database().delete();
         } catch (LiteCoreException e) {
             throw LiteCoreBridge.convertException(e);
         }
     }
 
-    private void freeC4DB() {
+    private void freeC4DB() throws IllegalStateException {
         if (c4db != null) {
-            internal().free();
+            getC4Database().free();
             c4db = null;
         }
     }
@@ -748,7 +753,7 @@ public final class Database {
     }
 
     private void postDatabaseChanged() {
-        if (c4DBObserver == null || c4db == null || internal().isInTransaction())
+        if (c4DBObserver == null || c4db == null || getC4Database().isInTransaction())
             return;
 
         int nChanges = 0;

--- a/shared/src/main/java/com/couchbase/lite/Document.java
+++ b/shared/src/main/java/com/couchbase/lite/Document.java
@@ -409,9 +409,9 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
     }
 
     // Reads the document from the db into a new C4Document and returns it, w/o affecting my state.
-    private com.couchbase.litecore.Document readC4Doc(boolean mustExist) throws CouchbaseLiteException {
+    private com.couchbase.litecore.Document readC4Doc(boolean mustExist) throws CouchbaseLiteException, IllegalStateException {
         try {
-            return database.internal().getDocument(getId(), mustExist);
+            return database.getC4Database().getDocument(getId(), mustExist);
         } catch (LiteCoreException e) {
             throw LiteCoreBridge.convertException(e);
         }
@@ -551,9 +551,8 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
         }
     }
 
-
     // Lower-level save method. On conflict, returns YES but sets *outDoc to NULL. */
-    private com.couchbase.litecore.Document save(boolean deletion) throws LiteCoreException {
+    private com.couchbase.litecore.Document save(boolean deletion) throws LiteCoreException, IllegalStateException {
 
         //String docID = this.id;
         byte[] body = null;
@@ -568,7 +567,7 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
             flags |= kRevHasAttachments;
         if (!deletion && !isEmpty()) {
             // Encode properties to Fleece data:
-            FLEncoder encoder = database.internal().createFleeceEncoder();
+            FLEncoder encoder = database.getC4Database().createFleeceEncoder();
             try {
                 body = encode(encoder);
             } finally {
@@ -580,7 +579,7 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
         }
 
         // Save to database:
-        return database.internal().put(getId(), body, false, false, history, flags, true, 0);
+        return database.getC4Database().put(getId(), body, false, false, history, flags, true, 0);
     }
 
     // #pragma mark - FLEECE ENCODING

--- a/shared/src/main/java/com/couchbase/lite/Query.java
+++ b/shared/src/main/java/com/couchbase/lite/Query.java
@@ -181,12 +181,12 @@ public class Query {
     // Private (in class only)
     //---------------------------------------------
 
-    private void check() throws CouchbaseLiteException {
+    private void check() throws CouchbaseLiteException, IllegalStateException {
         database = (Database) from.getSource();
         String json = encodeAsJSON();
         Log.v(LOG_TAG, "Query encoded as %s", json);
         try {
-            c4query = new C4Query(database.internal(), json);
+            c4query = new C4Query(database.getC4Database(), json);
         } catch (LiteCoreException e) {
             throw LiteCoreBridge.convertException(e);
         }

--- a/shared/src/main/java/com/couchbase/lite/Status.java
+++ b/shared/src/main/java/com/couchbase/lite/Status.java
@@ -5,7 +5,4 @@ package com.couchbase.lite;
 
     int Forbidden = 403;
     int NotFound = 404;
-
-
-    int DBClosed = 450; // TODO: Temporary value. Should be updated
 }

--- a/shared/src/main/java/com/couchbase/lite/Status.java
+++ b/shared/src/main/java/com/couchbase/lite/Status.java
@@ -5,4 +5,7 @@ package com.couchbase.lite;
 
     int Forbidden = 403;
     int NotFound = 404;
+
+
+    int DBClosed = 450; // TODO: Temporary value. Should be updated
 }


### PR DESCRIPTION
NOTE: Please review Database.java

- As temporary solution, If c4Database is already closed, CBL throws CouchbaseLiteException with DBClosed (450) code. NOTE: This is currently temporary.
- Database.internal() check if c4db is null. If it is null, throw CouchbaseLiteException.
- Reviewed other unit test failures with DatabaseTest.