### PR TITLE
Fixed #1243 - 2.0: Forum: NPE in Document.save()

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/BasicAuthenticator.java
+++ b/shared/src/main/java/com/couchbase/lite/BasicAuthenticator.java
@@ -3,6 +3,10 @@ package com.couchbase.lite;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.couchbase.lite.ReplicatorConfiguration.kCBLReplicatorAuthOption;
+import static com.couchbase.lite.ReplicatorConfiguration.kCBLReplicatorAuthPassword;
+import static com.couchbase.lite.ReplicatorConfiguration.kCBLReplicatorAuthUserName;
+
 /**
  * The BasicAuthenticator class is an authenticator that will authenticate using HTTP Basic
  * auth with the given username and password. This should only be used over an SSL/TLS connection,

--- a/shared/src/main/java/com/couchbase/lite/Document.java
+++ b/shared/src/main/java/com/couchbase/lite/Document.java
@@ -437,8 +437,8 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
                 if (e.domain != LiteCoreDomain || e.code != kC4ErrorConflict)
                     throw LiteCoreBridge.convertException(e);
             }
-            if (newDoc == null) {
 
+            if (newDoc == null) {
                 // There's been a conflict; first merge with the new saved revision:
                 merge(resolver, deletion);
 
@@ -460,7 +460,9 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
             try {
                 getDatabase().endTransaction(commit);
             } catch (CouchbaseLiteException e) {
-                newDoc.free();
+                // NOTE: newDoc could be null if initial save() throws Exception.
+                if (newDoc != null)
+                    newDoc.free();
                 throw e;
             }
         }

--- a/shared/src/main/java/com/couchbase/lite/SessionAuthenticator.java
+++ b/shared/src/main/java/com/couchbase/lite/SessionAuthenticator.java
@@ -6,6 +6,8 @@ import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
 
+import static com.couchbase.lite.ReplicatorConfiguration.kC4ReplicatorOptionCookies;
+
 /**
  * SessionAuthenticator class is an authenticator that will authenticate by using the sessin ID of
  * the session created by a Sync Gateway


### PR DESCRIPTION
- If initial `save(...)` method throws Exception, `newDoc` is `null`. Then causes NPE.