### PR TITLE
Fixed #1254 - 2.0: Why library force my app manifest to use `android:…

### DIFF
--- a/android/CouchbaseLite/src/main/AndroidManifest.xml
+++ b/android/CouchbaseLite/src/main/AndroidManifest.xml
@@ -1,11 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.couchbase.lite">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
-    <application
-        android:allowBackup="true"
-        android:label="@string/app_name"
-        android:supportsRtl="true"></application>
+    <application android:label="@string/app_name"></application>
 </manifest>


### PR DESCRIPTION
…allowBackup="true"`