### PR TITLE
Fixed #1265 - 2.0: CouchbaseLiteException should be RuntimeException …

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
@@ -69,7 +69,8 @@ public class ArrayTest extends BaseTest {
         void validate(T array);
     }
 
-    private void save(Document doc, String key, Array array, Validator<Array> validator) {
+    private void save(Document doc, String key, Array array, Validator<Array> validator)
+            throws CouchbaseLiteException {
         validator.validate(array);
 
         doc.set(key, array);
@@ -81,7 +82,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testCreate() {
+    public void testCreate() throws CouchbaseLiteException {
         Array array = new Array();
         assertEquals(0, array.count());
         assertEquals(new ArrayList<>(), array.toList());
@@ -95,7 +96,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testCreateWithList() {
+    public void testCreateWithList() throws CouchbaseLiteException {
         List<Object> data = new ArrayList<>();
         data.add("1");
         data.add("2");
@@ -113,7 +114,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testSetNSArray() {
+    public void testSetNSArray() throws CouchbaseLiteException {
         List<Object> data = new ArrayList<>();
         data.add("1");
         data.add("2");
@@ -144,7 +145,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testAddObjects() {
+    public void testAddObjects() throws CouchbaseLiteException {
         Array array = new Array();
 
         // Add objects of all types:
@@ -189,7 +190,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testAddObjectsToExistingArray() {
+    public void testAddObjectsToExistingArray() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
 
@@ -245,7 +246,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testSetObject() {
+    public void testSetObject() throws CouchbaseLiteException {
         List<Object> data = arrayOfAllTypes();
 
         // Prepare CBLArray with NSNull placeholders:
@@ -343,7 +344,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testInsertObjectToExistingArray() {
+    public void testInsertObjectToExistingArray() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         doc.set("array", new Array());
         doc = save(doc);
@@ -420,7 +421,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testRemove() {
+    public void testRemove() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
 
@@ -439,7 +440,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testRemoveExistingArray() {
+    public void testRemoveExistingArray() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
 
@@ -474,7 +475,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testCount() {
+    public void testCount() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
 
@@ -488,7 +489,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetString() {
+    public void testGetString() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -514,7 +515,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetNumber() {
+    public void testGetNumber() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -540,7 +541,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetInteger() {
+    public void testGetInteger() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -566,7 +567,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetLong() {
+    public void testGetLong() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -592,7 +593,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetFloat() {
+    public void testGetFloat() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -618,7 +619,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetDouble() {
+    public void testGetDouble() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -644,7 +645,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testSetGetMinMaxNumbers() {
+    public void testSetGetMinMaxNumbers() throws CouchbaseLiteException {
         Array array = new Array();
         array.add(Integer.MIN_VALUE);
         array.add(Integer.MAX_VALUE);
@@ -691,7 +692,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testSetGetFloatNumbers() {
+    public void testSetGetFloatNumbers() throws CouchbaseLiteException {
         Array array = new Array();
         array.add(1.00);
         array.add(1.49);
@@ -704,7 +705,8 @@ public class ArrayTest extends BaseTest {
             @Override
             public void validate(Array a) {
                 // NOTE: Number which has no floating part is stored as Integer.
-                //       This causes type difference between before and after storing data into the database.
+                //       This causes type difference between before and after storing data
+                //       into the database.
                 assertEquals(1.00, ((Number) a.getObject(0)).doubleValue(), 0.0);
                 assertEquals(1.00, a.getNumber(0).doubleValue(), 0.0);
                 assertEquals(1, a.getInt(0));
@@ -744,7 +746,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetBoolean() {
+    public void testGetBoolean() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -770,7 +772,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetDate() {
+    public void testGetDate() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -796,7 +798,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetMap() {
+    public void testGetMap() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -824,7 +826,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testGetArray() {
+    public void testGetArray() throws CouchbaseLiteException {
         Array array = new Array();
         populateData(array);
         assertEquals(12, array.count());
@@ -849,7 +851,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testSetNestedArray() {
+    public void testSetNestedArray() throws CouchbaseLiteException {
         Array array1 = new Array();
         Array array2 = new Array();
         Array array3 = new Array();
@@ -878,7 +880,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testReplaceArray() {
+    public void testReplaceArray() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         Array array1 = new Array();
         array1.add("a");
@@ -918,7 +920,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testReplaceArrayDifferentType() {
+    public void testReplaceArrayDifferentType() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         Array array1 = new Array();
         array1.add("a");
@@ -942,7 +944,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testEnumeratingArray() {
+    public void testEnumeratingArray() throws CouchbaseLiteException {
         Array array = new Array();
         for (int i = 0; i < 20; i++) {
             array.add(i);
@@ -990,7 +992,7 @@ public class ArrayTest extends BaseTest {
     }
 
     @Test
-    public void testArrayEnumerationWithDataModification() {
+    public void testArrayEnumerationWithDataModification() throws CouchbaseLiteException {
         Array array = new Array();
         for (int i = 0; i < 2; i++)
             array.add(i);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseTest.java
@@ -95,7 +95,7 @@ public class BaseTest {
         FileUtils.cleanDirectory(dir);
     }
 
-    protected Database open(String name){
+    protected Database open(String name) throws CouchbaseLiteException {
         DatabaseConfiguration options = new DatabaseConfiguration(this.context);
         options.setDirectory(dir);
         if (this.conflictResolver != null)
@@ -103,20 +103,20 @@ public class BaseTest {
         return new Database(name, options);
     }
 
-    protected void openDB() {
+    protected void openDB() throws CouchbaseLiteException {
         assertNull(db);
         db = open(kDatabaseName);
         assertNotNull(db);
     }
 
-    protected void closeDB() {
+    protected void closeDB() throws CouchbaseLiteException {
         if (db != null) {
             db.close();
             db = null;
         }
     }
 
-    protected void reopenDB() {
+    protected void reopenDB() throws CouchbaseLiteException {
         closeDB();
         openDB();
     }
@@ -150,7 +150,7 @@ public class BaseTest {
         return new Document(id, map);
     }
 
-    protected Document save(Document doc) {
+    protected Document save(Document doc) throws CouchbaseLiteException {
         db.save(doc);
         return db.getDocument(doc.getId());
     }
@@ -159,7 +159,8 @@ public class BaseTest {
         void validate(final T doc);
     }
 
-    protected Document save(Document doc, Validator<Document> validator) {
+    protected Document save(Document doc, Validator<Document> validator)
+            throws CouchbaseLiteException {
         validator.validate(doc);
         db.save(doc);
         doc = db.getDocument(doc.getId());
@@ -167,4 +168,3 @@ public class BaseTest {
         return doc;
     }
 }
-

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConflictTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConflictTest.java
@@ -1,6 +1,5 @@
 package com.couchbase.lite;
 
-
 import com.couchbase.litecore.fleece.FLEncoder;
 
 import org.junit.After;
@@ -21,8 +20,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 
 public class ConflictTest extends BaseTest {
-
-    //ReadOnlyDocument resolve(Conflict conflict);
 
     static class TheirsWins implements ConflictResolver {
         @Override
@@ -70,7 +67,7 @@ public class ConflictTest extends BaseTest {
         }
     }
 
-    private Document setupConflict() {
+    private Document setupConflict() throws CouchbaseLiteException {
         // Setup a default database conflict resolver
         Document doc = createDocument("doc1");
         doc.set("type", "profile");
@@ -88,13 +85,15 @@ public class ConflictTest extends BaseTest {
         return doc;
     }
 
-    private void save(final Map<String, Object> props, final String docID) {
+    private void save(final Map<String, Object> props, final String docID)
+            throws CouchbaseLiteException {
         // Save to database:
         db.inBatch(new Runnable() {
             @Override
             public void run() {
                 try {
-                    com.couchbase.litecore.Document trickey = db.getC4Database().getDocument(docID, true);
+                    com.couchbase.litecore.Document trickey
+                            = db.getC4Database().getDocument(docID, true);
                     FLEncoder enc = db.getC4Database().createFleeceEncoder();
                     enc.writeValue(props);
                     byte[] bytes = enc.finish();
@@ -117,11 +116,11 @@ public class ConflictTest extends BaseTest {
     }
 
     @Override
-    protected void openDB() {
+    protected void openDB() throws CouchbaseLiteException {
         openDB(new DoNotResolve());
     }
 
-    protected void openDB(ConflictResolver resolver) {
+    protected void openDB(ConflictResolver resolver) throws CouchbaseLiteException {
         assertNull(db);
 
         DatabaseConfiguration options = new DatabaseConfiguration(this.context);
@@ -142,7 +141,7 @@ public class ConflictTest extends BaseTest {
     }
 
     @Test
-    public void testConflict() {
+    public void testConflict() throws CouchbaseLiteException {
         closeDB();
         openDB(new TheirsWins());
 
@@ -178,7 +177,7 @@ public class ConflictTest extends BaseTest {
     }
 
     @Test
-    public void testConflictResolverGivesUp() {
+    public void testConflictResolverGivesUp() throws CouchbaseLiteException {
         closeDB();
         openDB(new GiveUp());
 
@@ -193,7 +192,7 @@ public class ConflictTest extends BaseTest {
     }
 
     @Test
-    public void testDeletionConflict() {
+    public void testDeletionConflict() throws CouchbaseLiteException {
         closeDB();
         openDB(new DoNotResolve());
 
@@ -204,7 +203,7 @@ public class ConflictTest extends BaseTest {
     }
 
     @Test
-    public void testConflictMineIsDeeper() {
+    public void testConflictMineIsDeeper() throws CouchbaseLiteException {
         closeDB();
         openDB(null);
 
@@ -214,7 +213,7 @@ public class ConflictTest extends BaseTest {
     }
 
     @Test
-    public void testConflictTheirsIsDeeper() {
+    public void testConflictTheirsIsDeeper() throws CouchbaseLiteException {
         closeDB();
         openDB(null);
 

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -378,8 +378,8 @@ public class DatabaseTest extends BaseTest {
         try {
             Document doc = db.getDocument("doc1");
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
-            // should be thrown CouchbaseLiteRuntimeException!!
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -393,8 +393,8 @@ public class DatabaseTest extends BaseTest {
         try {
             Document doc = db.getDocument("doc1");
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
-            // should be thrown CouchbaseLiteRuntimeException!!
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -529,8 +529,8 @@ public class DatabaseTest extends BaseTest {
         try {
             save(doc);
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
-            // should be thrown CouchbaseLiteRuntimeException!!
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -545,8 +545,8 @@ public class DatabaseTest extends BaseTest {
         try {
             save(doc);
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
-            // should be thrown CouchbaseLiteRuntimeException!!
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -693,8 +693,8 @@ public class DatabaseTest extends BaseTest {
         try {
             db.delete(doc);
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
-            // should be thrown CouchbaseLiteRuntimeException!!
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -710,8 +710,8 @@ public class DatabaseTest extends BaseTest {
         try {
             db.delete(doc);
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
-            // should be thrown CouchbaseLiteRuntimeException!!
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -851,8 +851,8 @@ public class DatabaseTest extends BaseTest {
         try {
             db.purge(doc);
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
-            // should be thrown CouchbaseLiteRuntimeException!!
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -868,8 +868,8 @@ public class DatabaseTest extends BaseTest {
         try {
             db.purge(doc);
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
-            // should be thrown CouchbaseLiteRuntimeException!!
+        } catch (IllegalStateException e) {
+            // should be thrown IllegalStateException!!
         }
     }
 
@@ -957,7 +957,7 @@ public class DatabaseTest extends BaseTest {
         try {
             deleteDatabase(db);
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
+        } catch (IllegalStateException e) {
             // should come here!
         }
     }
@@ -979,7 +979,7 @@ public class DatabaseTest extends BaseTest {
         try {
             db.delete();
             fail();
-        } catch (CouchbaseLiteRuntimeException e) {
+        } catch (IllegalStateException e) {
             // should come here!
         }
         assertFalse(path.exists());

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
@@ -18,7 +18,7 @@ import static org.junit.Assert.fail;
 
 public class DictionaryTest extends BaseTest {
     @Test
-    public void testCreateDictionary() {
+    public void testCreateDictionary() throws CouchbaseLiteException {
         Dictionary address = new Dictionary();
         assertEquals(0, address.count());
         assertEquals(new HashMap<String, Object>(), address.toMap());
@@ -33,7 +33,7 @@ public class DictionaryTest extends BaseTest {
     }
 
     @Test
-    public void testCreateDictionaryWithNSDictionary() {
+    public void testCreateDictionaryWithNSDictionary() throws CouchbaseLiteException {
         Map<String, Object> dict = new HashMap<>();
         dict.put("street", "1 Main street");
         dict.put("city", "Mountain View");
@@ -55,7 +55,7 @@ public class DictionaryTest extends BaseTest {
     }
 
     @Test
-    public void testGetValueFromNewEmptyDictionary() {
+    public void testGetValueFromNewEmptyDictionary() throws CouchbaseLiteException {
         Dictionary dict = new Dictionary();
 
         assertEquals(0, dict.getInt("key"));
@@ -94,7 +94,7 @@ public class DictionaryTest extends BaseTest {
     }
 
     @Test
-    public void testSetNestedDictionaries() {
+    public void testSetNestedDictionaries() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         Dictionary level1 = new Dictionary();
@@ -133,7 +133,7 @@ public class DictionaryTest extends BaseTest {
     }
 
     @Test
-    public void testDictionaryArray() {
+    public void testDictionaryArray() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         List<Object> data = new ArrayList<>();
@@ -186,7 +186,7 @@ public class DictionaryTest extends BaseTest {
     }
 
     @Test
-    public void testReplaceDictionary() {
+    public void testReplaceDictionary() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         Dictionary profile1 = new Dictionary();
@@ -218,7 +218,7 @@ public class DictionaryTest extends BaseTest {
     }
 
     @Test
-    public void testReplaceDictionaryDifferentType() {
+    public void testReplaceDictionaryDifferentType() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         Dictionary profile1 = new Dictionary();
@@ -245,7 +245,7 @@ public class DictionaryTest extends BaseTest {
     }
 
     @Test
-    public void testRemoveDictionary(){
+    public void testRemoveDictionary() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         Dictionary profile1 = new Dictionary();
         profile1.set("name", "Scott Tiger");
@@ -274,7 +274,7 @@ public class DictionaryTest extends BaseTest {
     }
 
     @Test
-    public void testEnumeratingKeys() {
+    public void testEnumeratingKeys() throws CouchbaseLiteException {
         final Dictionary dict = new Dictionary();
         for (int i = 0; i < 20; i++)
             dict.set(String.format(Locale.ENGLISH, "key%d", i), i);
@@ -325,7 +325,7 @@ public class DictionaryTest extends BaseTest {
     }
 
     @Test
-    public void testDictionaryEnumerationWithDataModification() {
+    public void testDictionaryEnumerationWithDataModification() throws CouchbaseLiteException {
         Dictionary dict = new Dictionary();
         for (int i = 0; i < 2; i++)
             dict.set(String.format(Locale.ENGLISH, "key%d", i), i);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
@@ -86,7 +86,7 @@ public class DocumentTest extends BaseTest {
 
 
     @Test
-    public void testCreateDoc() {
+    public void testCreateDoc() throws CouchbaseLiteException {
         Document doc1a = new Document();
         assertNotNull(doc1a);
         assertTrue(doc1a.getId().length() > 0);
@@ -104,7 +104,7 @@ public class DocumentTest extends BaseTest {
 
 
     @Test
-    public void testNewDocWithId() {
+    public void testNewDocWithId() throws CouchbaseLiteException {
         Document doc1a = createDocument("doc1");
         assertNotNull(doc1a);
         assertEquals("doc1", doc1a.getId());
@@ -134,7 +134,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testCreateDocWithNilID() {
+    public void testCreateDocWithNilID() throws CouchbaseLiteException {
         Document doc1a = createDocument(null);
         assertNotNull(doc1a);
         assertTrue(doc1a.getId().length() > 0);
@@ -151,7 +151,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testCreateDocWithDict() {
+    public void testCreateDocWithDict() throws CouchbaseLiteException {
         Map<String, Object> dict = new HashMap<>();
         dict.put("name", "Scott Tiger");
         dict.put("age", 30L);
@@ -181,7 +181,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testCreateDocWithIDAndDict() {
+    public void testCreateDocWithIDAndDict() throws CouchbaseLiteException {
         Map<String, Object> dict = new HashMap<>();
         dict.put("name", "Scott Tiger");
         dict.put("age", 30L);
@@ -211,7 +211,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetDictionaryContent() {
+    public void testSetDictionaryContent() throws CouchbaseLiteException {
         Map<String, Object> dict = new HashMap<>();
         dict.put("name", "Scott Tiger");
         dict.put("age", 30L);
@@ -254,7 +254,7 @@ public class DocumentTest extends BaseTest {
 
 
     @Test
-    public void testGetValueFromNewEmptyDoc() {
+    public void testGetValueFromNewEmptyDoc() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         save(doc, new Validator<Document>() {
             @Override
@@ -276,7 +276,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetValueFromExistingEmptyDoc() {
+    public void testGetValueFromExistingEmptyDoc() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         save(doc);
         doc = db.getDocument("doc1");
@@ -297,7 +297,7 @@ public class DocumentTest extends BaseTest {
 
 
     @Test
-    public void testSaveThenGetFromAnotherDB() {
+    public void testSaveThenGetFromAnotherDB() throws CouchbaseLiteException {
         Document doc1a = createDocument("doc1");
         doc1a.set("name", "Scott Tiger");
         save(doc1a);
@@ -311,7 +311,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testNoCacheNoLive() {
+    public void testNoCacheNoLive() throws CouchbaseLiteException {
         Document doc1a = createDocument("doc1");
         doc1a.set("name", "Scott Tiger");
 
@@ -345,7 +345,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetString() {
+    public void testSetString() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         doc.set("string1", "");
         doc.set("string2", "string");
@@ -369,7 +369,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetString() {
+    public void testGetString() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -393,7 +393,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetNumber() {
+    public void testSetNumber() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         doc.set("number1", 1);
@@ -430,7 +430,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetNumber() {
+    public void testGetNumber() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -454,7 +454,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetInteger() {
+    public void testGetInteger() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -478,7 +478,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetLong() {
+    public void testGetLong() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -502,7 +502,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetFloat() {
+    public void testGetFloat() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -526,7 +526,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetDouble() {
+    public void testGetDouble() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -550,7 +550,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetGetMinMaxNumbers() {
+    public void testSetGetMinMaxNumbers() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         doc.set("min_int", Integer.MIN_VALUE);
@@ -597,7 +597,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetGetFloatNumbers() {
+    public void testSetGetFloatNumbers() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         doc.set("number1", 1.00);
@@ -605,7 +605,6 @@ public class DocumentTest extends BaseTest {
         doc.set("number3", 1.50);
         doc.set("number4", 1.51);
         doc.set("number5", 1.99);
-
 
         save(doc, new Validator<Document>() {
             @Override
@@ -640,7 +639,7 @@ public class DocumentTest extends BaseTest {
                 assertEquals(1.51F, doc.getFloat("number4"), 0.0F);
                 assertEquals(1.51, doc.getDouble("number4"), 0.0);
 
-                assertEquals(1.99, ((Number) doc.getObject("number5")).doubleValue(), 0.0);  // return 1
+                assertEquals(1.99, ((Number) doc.getObject("number5")).doubleValue(), 0.0);// return 1
                 assertEquals(1.99, doc.getNumber("number5").doubleValue(), 0.0);  // return 1
                 // TODO: https://github.com/couchbaselabs/fleece/pull/19
                 //assertEquals(1, doc.getInt("number5"));
@@ -652,7 +651,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetBoolean() {
+    public void testSetBoolean() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         doc.set("boolean1", true);
@@ -685,7 +684,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetBoolean() {
+    public void testGetBoolean() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -709,7 +708,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetDate() {
+    public void testSetDate() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         Date date = new Date();
@@ -745,7 +744,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetDate() {
+    public void testGetDate() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -769,12 +768,11 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetBlob() {
+    public void testSetBlob() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         final Blob blob = new Blob("text/plain", kDocumentTestBlob.getBytes());
         doc.set("blob", blob);
-
 
         save(doc, new Validator<Document>() {
             @Override
@@ -809,7 +807,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetBlob() {
+    public void testGetBlob() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -827,14 +825,15 @@ public class DocumentTest extends BaseTest {
                 assertNull(d.getBlob("dict"));
                 assertNull(d.getBlob("array"));
                 assertEquals(kDocumentTestBlob, new String(d.getBlob("blob").getContent()));
-                assertTrue(Arrays.equals(kDocumentTestBlob.getBytes(), d.getBlob("blob").getContent()));
+                assertTrue(Arrays.equals(kDocumentTestBlob.getBytes(),
+                        d.getBlob("blob").getContent()));
                 assertNull(d.getBlob("non_existing_key"));
             }
         });
     }
 
     @Test
-    public void testSetDictionary() {
+    public void testSetDictionary() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         Dictionary dict = new Dictionary();
@@ -871,7 +870,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetDictionary() {
+    public void testGetDictionary() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -899,7 +898,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetArray() {
+    public void testSetArray() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         Array array = new Array();
@@ -933,7 +932,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testGetArray() {
+    public void testGetArray() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
         save(doc, new Validator<Document>() {
@@ -958,7 +957,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetNull() {
+    public void testSetNull() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         doc.set("null", null);
         assertEquals(1, doc.count());
@@ -972,7 +971,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetMap() {
+    public void testSetMap() throws CouchbaseLiteException {
         Map<String, Object> dict = new HashMap<>();
         dict.put("street", "1 Main street");
         dict.put("city", "Mountain View");
@@ -1023,7 +1022,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetList() {
+    public void testSetList() throws CouchbaseLiteException {
         List<String> array = Arrays.asList("a", "b", "c");
 
         Document doc = createDocument("doc1");
@@ -1070,7 +1069,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testUpdateNestedDictionary() {
+    public void testUpdateNestedDictionary() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         Dictionary addresses = new Dictionary();
         doc.set("addresses", addresses);
@@ -1102,7 +1101,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testUpdateDictionaryInArray() {
+    public void testUpdateDictionaryInArray() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         Array addresses = new Array();
         doc.set("addresses", addresses);
@@ -1150,7 +1149,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testUpdateNestedArray() {
+    public void testUpdateNestedArray() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         Array groups = new Array();
         doc.set("groups", groups);
@@ -1182,12 +1181,13 @@ public class DocumentTest extends BaseTest {
         doc = save(doc);
 
         Map<String, Object> expected = new HashMap<>();
-        expected.put("groups", Arrays.asList(Arrays.asList("d", "e", "f"), Arrays.asList(4L, 5L, 6L)));
+        expected.put("groups", Arrays.asList(Arrays.asList("d", "e", "f"),
+                Arrays.asList(4L, 5L, 6L)));
         assertEquals(expected, doc.toMap());
     }
 
     @Test
-    public void testUpdateArrayInDictionary() {
+    public void testUpdateArrayInDictionary() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         Dictionary group1 = new Dictionary();
@@ -1231,7 +1231,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetDictionaryToMultipleKeys() {
+    public void testSetDictionaryToMultipleKeys() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         Dictionary address = new Dictionary();
@@ -1266,7 +1266,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testSetArrayToMultipleKeys() {
+    public void testSetArrayToMultipleKeys() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
 
         Array phones = new Array();
@@ -1282,8 +1282,10 @@ public class DocumentTest extends BaseTest {
         // Update phones: both mobile and home should get the update
         phones.add("650-000-0003");
 
-        assertEquals(Arrays.asList("650-000-0001", "650-000-0002", "650-000-0003"), doc.getArray("mobile").toList());
-        assertEquals(Arrays.asList("650-000-0001", "650-000-0002", "650-000-0003"), doc.getArray("home").toList());
+        assertEquals(Arrays.asList("650-000-0001", "650-000-0002", "650-000-0003"),
+                doc.getArray("mobile").toList());
+        assertEquals(Arrays.asList("650-000-0001", "650-000-0002", "650-000-0003"),
+                doc.getArray("home").toList());
 
         doc = save(doc);
 
@@ -1301,8 +1303,10 @@ public class DocumentTest extends BaseTest {
         // Save update:
         doc = save(doc);
 
-        assertEquals(Arrays.asList("650-000-0001", "650-000-0002", "650-000-0003", "650-000-1234"), doc.getArray("mobile").toList());
-        assertEquals(Arrays.asList("650-000-0001", "650-000-0002", "650-000-0003", "650-000-5678"), doc.getArray("home").toList());
+        assertEquals(Arrays.asList("650-000-0001", "650-000-0002", "650-000-0003", "650-000-1234"),
+                doc.getArray("mobile").toList());
+        assertEquals(Arrays.asList("650-000-0001", "650-000-0002", "650-000-0003", "650-000-5678"),
+                doc.getArray("home").toList());
     }
 
     @Test
@@ -1313,7 +1317,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testCount() {
+    public void testCount() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         populateData(doc);
 
@@ -1327,7 +1331,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testRemoveKeys() {
+    public void testRemoveKeys() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         Map<String, Object> mapAddress = new HashMap<>();
         mapAddress.put("street", "1 milky way.");
@@ -1414,7 +1418,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testDeleteDocument() {
+    public void testDeleteDocument() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         doc.set("name", "Scott Tiger");
         assertFalse(doc.isDeleted());
@@ -1430,7 +1434,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testDictionaryAfterDeleteDocument() {
+    public void testDictionaryAfterDeleteDocument() throws CouchbaseLiteException {
         Map<String, Object> addr = new HashMap<>();
         addr.put("street", "1 Main street");
         addr.put("city", "Mountain View");
@@ -1462,7 +1466,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testArrayAfterDeleteDocument() {
+    public void testArrayAfterDeleteDocument() throws CouchbaseLiteException {
         Map<String, Object> dict = new HashMap<>();
         dict.put("members", Arrays.asList("a", "b", "c"));
 
@@ -1492,11 +1496,10 @@ public class DocumentTest extends BaseTest {
         members.add("2");
         assertNull(doc.getDictionary("members"));
         assertEquals(new HashMap<>(), doc.toMap());
-
     }
 
     @Test
-    public void testPurgeDocument() {
+    public void testPurgeDocument() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         doc.set("type", "profile");
         doc.set("name", "Scott");
@@ -1524,7 +1527,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testReopenDB() {
+    public void testReopenDB() throws CouchbaseLiteException {
         Document doc = createDocument("doc1");
         doc.set("string", "str");
         save(doc);
@@ -1539,7 +1542,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testBlob() throws IOException {
+    public void testBlob() throws IOException, CouchbaseLiteException {
         byte[] content = kDocumentTestBlob.getBytes();
 
         // store blob
@@ -1573,7 +1576,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testEmptyBlob() throws IOException {
+    public void testEmptyBlob() throws IOException, CouchbaseLiteException {
         byte[] content = "".getBytes();
         Blob data = new Blob("text/plain", content);
         assertNotNull(data);
@@ -1603,7 +1606,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testBlobWithStream() throws IOException {
+    public void testBlobWithStream() throws IOException, CouchbaseLiteException {
         Document doc = createDocument("doc1");
         byte[] content = "".getBytes();
         InputStream stream = new ByteArrayInputStream(content);
@@ -1636,7 +1639,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testMultipleBlobRead() throws IOException {
+    public void testMultipleBlobRead() throws IOException, CouchbaseLiteException {
         byte[] content = kDocumentTestBlob.getBytes();
         Blob data = new Blob("text/plain", content);
         assertNotNull(data);
@@ -1685,7 +1688,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testReadExistingBlob() {
+    public void testReadExistingBlob() throws CouchbaseLiteException {
         byte[] content = kDocumentTestBlob.getBytes();
         Blob data = new Blob("text/plain", content);
         assertNotNull(data);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/MigrationTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/MigrationTest.java
@@ -41,7 +41,7 @@ public class MigrationTest extends BaseTest {
      * Tool to generate test db
      */
     //NOTE: @Test
-    public void testPrepareDB() {
+    public void testPrepareDB() throws CouchbaseLiteException {
         Database db = new Database("android-sqlite", new DatabaseConfiguration(context));
         try {
             for (int i = 1; i <= 2; i++) {
@@ -139,7 +139,7 @@ public class MigrationTest extends BaseTest {
     }
 
     //  // if db exist, delete it
-    private void deleteDB(String name, File dir) {
+    private void deleteDB(String name, File dir) throws CouchbaseLiteException {
         // database exist, delete it
         if (Database.exists("android-sqlite", context.getFilesDir())) {
             // sometimes, db is still in used, wait for a while. Maximum 3 sec

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/NotificationTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/NotificationTest.java
@@ -13,7 +13,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-
 public class NotificationTest extends BaseTest {
 
     @Before
@@ -27,7 +26,8 @@ public class NotificationTest extends BaseTest {
     }
 
     @Test
-    public void testDatabaseNotification() throws InterruptedException {
+    public void testDatabaseNotification()
+            throws InterruptedException, CouchbaseLiteException {
         final CountDownLatch latch = new CountDownLatch(1);
         db.addChangeListener(new DatabaseChangeListener() {
             @Override
@@ -46,7 +46,11 @@ public class NotificationTest extends BaseTest {
                 for (int i = 0; i < 10; i++) {
                     Document doc = createDocument(String.format(Locale.ENGLISH, "doc-%d", i));
                     doc.set("type", "demo");
-                    save(doc);
+                    try {
+                        save(doc);
+                    } catch (CouchbaseLiteException e) {
+                        throw new RuntimeException(e);
+                    }
                 }
             }
         });
@@ -54,7 +58,8 @@ public class NotificationTest extends BaseTest {
     }
 
     @Test
-    public void testDocumentNotification() throws InterruptedException {
+    public void testDocumentNotification()
+            throws InterruptedException, CouchbaseLiteException {
         Document docA = createDocument("A");
         Document docB = createDocument("B");
 
@@ -113,7 +118,8 @@ public class NotificationTest extends BaseTest {
     }
 
     @Test
-    public void testExternalChanges() throws InterruptedException {
+    public void testExternalChanges()
+            throws InterruptedException, CouchbaseLiteException {
         final Database db2 = db.copy();
         assertNotNull(db2);
         try {
@@ -147,7 +153,11 @@ public class NotificationTest extends BaseTest {
                     for (int i = 0; i < 10; i++) {
                         Document doc = createDocument(String.format(Locale.ENGLISH, "doc-%d", i));
                         doc.set("type", "demo");
-                        save(doc);
+                        try {
+                            save(doc);
+                        } catch (CouchbaseLiteException e) {
+                            throw new RuntimeException(e);
+                        }
                     }
                 }
             });
@@ -160,7 +170,8 @@ public class NotificationTest extends BaseTest {
     }
 
     @Test
-    public void testAddSameChangeListeners() throws InterruptedException {
+    public void testAddSameChangeListeners()
+            throws InterruptedException, CouchbaseLiteException {
         Document doc1 = createDocument("doc1");
         doc1.set("name", "Scott");
         save(doc1);
@@ -190,7 +201,8 @@ public class NotificationTest extends BaseTest {
     }
 
     @Test
-    public void testRemoveDocumentChangeListener() throws InterruptedException {
+    public void testRemoveDocumentChangeListener()
+            throws InterruptedException, CouchbaseLiteException {
         Document doc1 = createDocument("doc1");
         doc1.set("name", "Scott");
         save(doc1);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
@@ -50,7 +50,7 @@ public class QueryTest extends BaseTest {
         return n;
     }
 
-    private Document createDocNumbered(int i, int num) {
+    private Document createDocNumbered(int i, int num) throws CouchbaseLiteException {
         String docID = String.format(Locale.ENGLISH, "doc%d", i);
         Document doc = createDocument(docID);
         doc.set("number1", i);
@@ -64,7 +64,12 @@ public class QueryTest extends BaseTest {
             @Override
             public void run() {
                 for (int i = 1; i <= num; i++) {
-                    Document doc = createDocNumbered(i, num);
+                    Document doc = null;
+                    try {
+                        doc = createDocNumbered(i, num);
+                    } catch (CouchbaseLiteException e) {
+                        throw new RuntimeException(e);
+                    }
                     numbers.add(doc.toMap());
                 }
             }
@@ -660,7 +665,11 @@ public class QueryTest extends BaseTest {
                     .postDelayed(new Runnable() {
                         @Override
                         public void run() {
-                            createDocNumbered(-1, 100);
+                            try {
+                                createDocNumbered(-1, 100);
+                            } catch (CouchbaseLiteException e) {
+                                throw new RuntimeException(e);
+                            }
                         }
                     }, 500); // 500ms
 
@@ -713,7 +722,11 @@ public class QueryTest extends BaseTest {
                     .postDelayed(new Runnable() {
                         @Override
                         public void run() {
-                            createDocNumbered(111, 100);
+                            try {
+                                createDocNumbered(111, 100);
+                            } catch (CouchbaseLiteException e) {
+                                throw new RuntimeException(e);
+                            }
                         }
                     }, 500); // 500ms
             // wait till listener is called

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorTest.java
@@ -34,29 +34,34 @@ public class ReplicatorTest extends BaseTest {
     Replicator repl;
     long timeout;  // seconds
 
-    private ReplicatorConfiguration makeConfig(boolean push, boolean pull, boolean continuous) {
+    private ReplicatorConfiguration makeConfig(boolean push, boolean pull,
+                                               boolean continuous) {
         return makeConfig(push, pull, continuous, otherDB);
     }
 
-    private ReplicatorConfiguration makeConfig(boolean push, boolean pull, boolean continuous, String uri) {
+    private ReplicatorConfiguration makeConfig(boolean push, boolean pull,
+                                               boolean continuous, String uri) {
         return makeConfig(push, pull, continuous, URI.create(uri));
     }
 
-    private ReplicatorConfiguration makeConfig(boolean push, boolean pull, boolean continuous, URI target) {
+    private ReplicatorConfiguration makeConfig(boolean push, boolean pull,
+                                               boolean continuous, URI target) {
         ReplicatorConfiguration config = new ReplicatorConfiguration(db, target);
         config.setReplicatorType(push && pull ? PUSH_AND_PULL : (push ? PUSH : PULL));
         config.setContinuous(continuous);
         return config;
     }
 
-    private ReplicatorConfiguration makeConfig(boolean push, boolean pull, boolean continuous, Database target) {
+    private ReplicatorConfiguration makeConfig(boolean push, boolean pull,
+                                               boolean continuous, Database target) {
         ReplicatorConfiguration config = new ReplicatorConfiguration(db, target);
         config.setReplicatorType(push && pull ? PUSH_AND_PULL : (push ? PUSH : PULL));
         config.setContinuous(continuous);
         return config;
     }
 
-    private void run(final ReplicatorConfiguration config, final int code, final String domain) throws InterruptedException {
+    private void run(final ReplicatorConfiguration config, final int code, final String domain)
+            throws InterruptedException {
         repl = new Replicator(config);
         final CountDownLatch latch = new CountDownLatch(1);
         repl.addChangeListener(new ReplicatorChangeListener() {
@@ -99,7 +104,8 @@ public class ReplicatorTest extends BaseTest {
 
     @Before
     public void setUp() throws Exception {
-        config = new Config(InstrumentationRegistry.getContext().getAssets().open(Config.TEST_PROPERTIES_FILE));
+        config = new Config(
+                InstrumentationRegistry.getContext().getAssets().open(Config.TEST_PROPERTIES_FILE));
         if (!config.replicatorTestsEnabled())
             return;
 
@@ -277,7 +283,8 @@ public class ReplicatorTest extends BaseTest {
         if (!config.replicatorTestsEnabled())
             return;
 
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/db", this.config.remoteHost(), this.config.remotePort());
+        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/db",
+                this.config.remoteHost(), this.config.remotePort());
         ReplicatorConfiguration config = makeConfig(true, false, false, uri);
         run(config, 0, null);
     }
@@ -287,7 +294,8 @@ public class ReplicatorTest extends BaseTest {
         if (!config.replicatorTestsEnabled())
             return;
 
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/db", this.config.remoteHost(), this.config.remotePort());
+        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/db",
+                this.config.remoteHost(), this.config.remotePort());
         ReplicatorConfiguration config = makeConfig(false, true, false, uri);
         run(config, 0, null);
     }
@@ -299,7 +307,8 @@ public class ReplicatorTest extends BaseTest {
 
         loadJSONResource("names_100.json");
 
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/db", this.config.remoteHost(), this.config.remotePort());
+        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/db",
+                this.config.remoteHost(), this.config.remotePort());
         ReplicatorConfiguration config = makeConfig(true, false, false, uri);
         run(config, 0, null);
     }
@@ -309,7 +318,8 @@ public class ReplicatorTest extends BaseTest {
     public void testAuthenticationFailure() throws InterruptedException {
         if (!config.replicatorTestsEnabled())
             return;
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit", this.config.remoteHost(), this.config.remotePort());
+        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit",
+                this.config.remoteHost(), this.config.remotePort());
         ReplicatorConfiguration config = makeConfig(false, true, false, uri);
         run(config, 401, "WebSocket");
     }
@@ -318,7 +328,8 @@ public class ReplicatorTest extends BaseTest {
     public void testAuthenticatedPullWithIncorrectPassword() throws InterruptedException {
         if (!config.replicatorTestsEnabled())
             return;
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit", this.config.remoteHost(), this.config.remotePort());
+        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit",
+                this.config.remoteHost(), this.config.remotePort());
         ReplicatorConfiguration config = makeConfig(false, true, false, uri);
         config.setAuthenticator(new BasicAuthenticator("pupshaw", "frank!"));
         // Retry 3 times then fails with 401
@@ -329,7 +340,8 @@ public class ReplicatorTest extends BaseTest {
     public void testAuthenticatedPullHardcoded() throws InterruptedException {
         if (!config.replicatorTestsEnabled())
             return;
-        String uri = String.format(Locale.ENGLISH, "blip://pupshaw:frank@%s:%d/seekrit", this.config.remoteHost(), this.config.remotePort());
+        String uri = String.format(Locale.ENGLISH, "blip://pupshaw:frank@%s:%d/seekrit",
+                this.config.remoteHost(), this.config.remotePort());
         ReplicatorConfiguration config = makeConfig(false, true, false, uri);
         run(config, 0, null);
     }
@@ -338,7 +350,8 @@ public class ReplicatorTest extends BaseTest {
     public void testAuthenticatedPull() throws InterruptedException {
         if (!config.replicatorTestsEnabled())
             return;
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit", this.config.remoteHost(), this.config.remotePort());
+        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit",
+                this.config.remoteHost(), this.config.remotePort());
         ReplicatorConfiguration config = makeConfig(false, true, false, uri);
         config.setAuthenticator(new BasicAuthenticator("pupshaw", "frank"));
         run(config, 0, null);
@@ -351,7 +364,8 @@ public class ReplicatorTest extends BaseTest {
     public void testSelfSignedSSLFailure() throws InterruptedException {
         if (!config.replicatorTestsEnabled())
             return;
-        String uri = String.format(Locale.ENGLISH, "blips://%s:4994/beer", this.config.remoteHost());
+        String uri = String.format(Locale.ENGLISH, "blips://%s:4994/beer",
+                this.config.remoteHost());
         ReplicatorConfiguration config = makeConfig(false, true, false, uri);
         run(config, kC4NetErrTLSCertUntrusted, "Network");
     }
@@ -372,7 +386,8 @@ public class ReplicatorTest extends BaseTest {
         byte[] cert = IOUtils.toByteArray(is);
         is.close();
 
-        String uri = String.format(Locale.ENGLISH, "blips://%s:4994/beer", this.config.remoteHost());
+        String uri = String.format(Locale.ENGLISH, "blips://%s:4994/beer",
+                this.config.remoteHost());
         ReplicatorConfiguration config = makeConfig(false, true, false, uri);
         config.setPinnedServerCertificate(cert);
         run(config, 0, null);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/internal/support/URIUtilsTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/internal/support/URIUtilsTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.assertEquals;
 
 public class URIUtilsTest {
     @Test
-    public void testGetPort() throws URISyntaxException{
+    public void testGetPort() throws URISyntaxException {
         URI uri = new URI("blip://foo.couchbase.com/db");
         assertEquals(-1, uri.getPort());
     }

--- a/android/CouchbaseLite/src/main/java/com/couchbase/lite/AndroidNetworkReachabilityManager.java
+++ b/android/CouchbaseLite/src/main/java/com/couchbase/lite/AndroidNetworkReachabilityManager.java
@@ -23,7 +23,7 @@ import android.net.NetworkInfo;
 /**
  * NOTE: https://developer.android.com/training/basics/network-ops/managing.html
  */
-/* package */ class AndroidNetworkReachabilityManager extends NetworkReachabilityManager {
+class AndroidNetworkReachabilityManager extends NetworkReachabilityManager {
 
     private static final String TAG = Log.SYNC;
 
@@ -31,7 +31,7 @@ import android.net.NetworkInfo;
     private Context context;
     private NetworkReceiver receiver;
 
-    /* package */ AndroidNetworkReachabilityManager(Context context) {
+    AndroidNetworkReachabilityManager(Context context) {
         this.listening = false;
         this.context = context;
         this.receiver = new NetworkReceiver();

--- a/android/CouchbaseLite/src/main/java/com/couchbase/lite/DatabaseConfiguration.java
+++ b/android/CouchbaseLite/src/main/java/com/couchbase/lite/DatabaseConfiguration.java
@@ -26,11 +26,11 @@ public class DatabaseConfiguration extends BaseDatabaseConfiguration {
     // Package level access
     //---------------------------------------------
 
-    /* package */ Context getContext() {
+    Context getContext() {
         return context;
     }
 
-    /* package */ DatabaseConfiguration copy() {
+    DatabaseConfiguration copy() {
         DatabaseConfiguration config = new DatabaseConfiguration();
         config.context = this.context;
         config.setConflictResolver(this.getConflictResolver());

--- a/shared/src/main/java/com/couchbase/lite/Array.java
+++ b/shared/src/main/java/com/couchbase/lite/Array.java
@@ -45,7 +45,7 @@ public class Array extends ReadOnlyArray implements ArrayInterface, FleeceEncoda
         set(array);
     }
 
-    /* package */ Array(CBLFLArray data) {
+    Array(CBLFLArray data) {
         super(data);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/ArrayInterface.java
+++ b/shared/src/main/java/com/couchbase/lite/ArrayInterface.java
@@ -2,7 +2,7 @@ package com.couchbase.lite;
 
 import java.util.List;
 
-/*package*/ interface ArrayInterface extends ReadOnlyArrayInterface {
+interface ArrayInterface extends ReadOnlyArrayInterface {
     ArrayInterface set(List<Object> list);
 
     ArrayInterface set(int index, Object value);

--- a/shared/src/main/java/com/couchbase/lite/BasicAuthenticator.java
+++ b/shared/src/main/java/com/couchbase/lite/BasicAuthenticator.java
@@ -47,7 +47,7 @@ public class BasicAuthenticator extends Authenticator {
     //---------------------------------------------
 
     @Override
-    /* package */ void authenticate(Map<String, Object> options) {
+    void authenticate(Map<String, Object> options) {
         Map<String, Object> auth = new HashMap<>();
         auth.put(kCBLReplicatorAuthUserName, username);
         auth.put(kCBLReplicatorAuthPassword, password);

--- a/shared/src/main/java/com/couchbase/lite/Blob.java
+++ b/shared/src/main/java/com/couchbase/lite/Blob.java
@@ -48,12 +48,12 @@ public final class Blob implements FleeceEncodable {
     // static constant variables
     //---------------------------------------------
 
-    /* package */ static final String TAG = Log.BLOB;
-    /* package */ static final String TYPE_META_PROPERTY = "_cbltype";
-    /* package */ static final String BLOB_TYPE = "blob";
+    static final String TAG = Log.BLOB;
+    static final String TYPE_META_PROPERTY = "_cbltype";
+    static final String BLOB_TYPE = "blob";
 
     // Max size of data that will be cached in memory with the CBLBlob
-    /* package */ static final int MAX_CACHED_CONTENT_LENGTH = 8 * 1024;
+    static final int MAX_CACHED_CONTENT_LENGTH = 8 * 1024;
 
     //---------------------------------------------
     // member variables
@@ -136,7 +136,7 @@ public final class Blob implements FleeceEncodable {
     }
 
     // Initializer for an existing blob being read from a document
-    /* package */ Blob(Database database, Map<String, Object> properties) {
+    Blob(Database database, Map<String, Object> properties) {
         this.database = database;
         this.properties = new HashMap<>(properties);
         this.properties.remove(TYPE_META_PROPERTY);
@@ -208,7 +208,7 @@ public final class Blob implements FleeceEncodable {
                     length = content.length;
                 } catch (IOException e) {
                     Log.w(TAG, "I/O Error with the given stream.", e);
-                    throw new CouchbaseLiteException(e);
+                    throw new CouchbaseLiteRuntimeException(e);
                 } finally {
                     try {
                         initialContentStream.close();
@@ -301,13 +301,13 @@ public final class Blob implements FleeceEncodable {
     // Package level access
     //---------------------------------------------
 
-    /* package */ Map<String, Object> jsonRepresentation() {
+    Map<String, Object> jsonRepresentation() {
         Map<String, Object> json = new HashMap<>(getProperties());
         json.put(TYPE_META_PROPERTY, BLOB_TYPE);
         return json;
     }
 
-    /* package */ void installInDatabase(Database db) throws CouchbaseLiteException {
+    void installInDatabase(Database db) {
         if (db == null)
             throw new IllegalArgumentException("database is null");
 
@@ -324,11 +324,7 @@ public final class Blob implements FleeceEncodable {
             C4BlobStore store = getBlobStore(db);
             try {
                 if (content != null) {
-                    try {
-                        key = store.create(content);
-                    } catch (LiteCoreException e) {
-                        throw LiteCoreBridge.convertException(e);
-                    }
+                    key = store.create(content);
                 } else {
                     C4BlobWriteStream blobOut = store.openWriteStream();
                     try {
@@ -361,9 +357,9 @@ public final class Blob implements FleeceEncodable {
                     store.free();
             }
         } catch (LiteCoreException e) {
-            throw LiteCoreBridge.convertException(e);
+            throw LiteCoreBridge.convertRuntimeException(e);
         } catch (IOException ioe) {
-            throw new CouchbaseLiteException(ioe);
+            throw new CouchbaseLiteRuntimeException(ioe);
         } finally {
             if (key != null)
                 key.free();
@@ -372,7 +368,7 @@ public final class Blob implements FleeceEncodable {
 
     // FleeceEncodable implementation
     @Override
-    public void fleeceEncode(FLEncoder encoder, Database database) throws CouchbaseLiteException {
+    public void fleeceEncode(FLEncoder encoder, Database database) {
         installInDatabase(database);
 
         Map<String, Object> dict = jsonRepresentation();

--- a/shared/src/main/java/com/couchbase/lite/BlobInputStream.java
+++ b/shared/src/main/java/com/couchbase/lite/BlobInputStream.java
@@ -9,14 +9,14 @@ import com.couchbase.litecore.LiteCoreException;
 import java.io.IOException;
 import java.io.InputStream;
 
-/* package */ class BlobInputStream extends InputStream {
+class BlobInputStream extends InputStream {
     C4BlobStore store = null;
     C4BlobKey key = null;
     boolean hasBytesAvailable = false;
     boolean closed = true;
     C4BlobReadStream readStream = null;
 
-    /* package */ BlobInputStream(C4BlobStore store, C4BlobKey key) throws CouchbaseLiteException {
+    BlobInputStream(C4BlobStore store, C4BlobKey key) {
         if (key == null)
             throw new IllegalArgumentException("key is null.");
         if (store == null) {
@@ -31,7 +31,7 @@ import java.io.InputStream;
             this.hasBytesAvailable = true;
             this.closed = false;
         } catch (LiteCoreException e) {
-            throw LiteCoreBridge.convertException(e);
+            throw LiteCoreBridge.convertRuntimeException(e);
         }
     }
 

--- a/shared/src/main/java/com/couchbase/lite/CBLC4Doc.java
+++ b/shared/src/main/java/com/couchbase/lite/CBLC4Doc.java
@@ -3,10 +3,10 @@ package com.couchbase.lite;
 
 import com.couchbase.litecore.LiteCoreException;
 
-/*package*/ class CBLC4Doc {
+class CBLC4Doc {
     private com.couchbase.litecore.Document rawDoc;
 
-    /*package*/ CBLC4Doc(com.couchbase.litecore.Document rawDoc) {
+    CBLC4Doc(com.couchbase.litecore.Document rawDoc) {
         this.rawDoc = rawDoc;
     }
 
@@ -16,23 +16,23 @@ import com.couchbase.litecore.LiteCoreException;
         super.finalize();
     }
 
-    /*package*/ com.couchbase.litecore.Document getRawDoc() {
+    com.couchbase.litecore.Document getRawDoc() {
         return rawDoc;
     }
 
-    /*package*/ int getFlags() {
+    int getFlags() {
         return rawDoc.getFlags();
     }
 
-    /*package*/ long getSequence() {
+    long getSequence() {
         return rawDoc.getSequence();
     }
 
-    /*package*/ String getRevID() {
+    String getRevID() {
         return rawDoc.getRevID();
     }
 
-    /*package*/ void free() {
+    void free() {
         if (rawDoc != null) {
             rawDoc.free();
             rawDoc = null;
@@ -41,19 +41,19 @@ import com.couchbase.litecore.LiteCoreException;
 
     // --- Following is Java only methods
 
-    /*package*/String getSelectedRevID() {
+    String getSelectedRevID() {
         return rawDoc.getSelectedRevID();
     }
 
-    /*package*/ byte[] getSelectedBody() throws LiteCoreException {
+    byte[] getSelectedBody() throws LiteCoreException {
         return rawDoc.getSelectedBody();
     }
 
-    /*package*/ long getSelectedSequence() {
+    long getSelectedSequence() {
         return rawDoc.getSelectedSequence();
     }
 
-    /*package*/ long getSelectedRevFlags() {
+    long getSelectedRevFlags() {
         return rawDoc.getSelectedRevFlags();
     }
 }

--- a/shared/src/main/java/com/couchbase/lite/CBLData.java
+++ b/shared/src/main/java/com/couchbase/lite/CBLData.java
@@ -15,8 +15,7 @@ import static com.couchbase.litecore.fleece.FLConstants.FLValueType.kFLArray;
 import static com.couchbase.litecore.fleece.FLConstants.FLValueType.kFLDict;
 
 // CBLData.mm
-/*package*/ class CBLData {
-    /* package */
+class CBLData {
     static Object convert(Object value) {
         if (value instanceof Dictionary) {
             return value;
@@ -51,7 +50,6 @@ import static com.couchbase.litecore.fleece.FLConstants.FLValueType.kFLDict;
         return value;
     }
 
-    /*package*/
     static boolean toBoolean(Object object) {
         if (object == null)
             return false;
@@ -68,7 +66,6 @@ import static com.couchbase.litecore.fleece.FLConstants.FLValueType.kFLDict;
     // + (id) fleeceValueToObject: (FLValue)value
     //                      c4doc: (CBLC4Document*)c4doc
     //                  database: (CBLDatabase*)database
-    /*package*/
     static Object fleeceValueToObject(FLValue value, CBLC4Doc c4doc, Database database) {
         if (value == null) return null;
         switch (value.getType()) {

--- a/shared/src/main/java/com/couchbase/lite/CBLFLArray.java
+++ b/shared/src/main/java/com/couchbase/lite/CBLFLArray.java
@@ -2,26 +2,26 @@ package com.couchbase.lite;
 
 import com.couchbase.litecore.fleece.FLArray;
 
-/*package*/ class CBLFLArray {
+class CBLFLArray {
     private FLArray flArray;
     private CBLC4Doc c4doc;
     private Database database;
 
-    /*package*/  CBLFLArray(FLArray array, CBLC4Doc c4doc, Database database) {
+    CBLFLArray(FLArray array, CBLC4Doc c4doc, Database database) {
         this.flArray = array;
         this.c4doc = c4doc;
         this.database = database;
     }
 
-    /*package*/  FLArray getFLArray() {
+    FLArray getFLArray() {
         return flArray;
     }
 
-    /*package*/  CBLC4Doc getC4doc() {
+    CBLC4Doc getC4doc() {
         return c4doc;
     }
 
-    /*package*/  Database getDatabase() {
+    Database getDatabase() {
         return database;
     }
 }

--- a/shared/src/main/java/com/couchbase/lite/CBLFLDict.java
+++ b/shared/src/main/java/com/couchbase/lite/CBLFLDict.java
@@ -2,26 +2,26 @@ package com.couchbase.lite;
 
 import com.couchbase.litecore.fleece.FLDict;
 
-/*package*/ class CBLFLDict {
+class CBLFLDict {
     private FLDict flDict;
     private CBLC4Doc c4doc;
     private Database database;
 
-    /*package*/ CBLFLDict(FLDict dict, CBLC4Doc c4doc, Database database) {
+    CBLFLDict(FLDict dict, CBLC4Doc c4doc, Database database) {
         this.flDict = dict;
         this.c4doc = c4doc;
         this.database = database;
     }
 
-    /*package*/ FLDict getFlDict() {
+    FLDict getFlDict() {
         return flDict;
     }
 
-    /*package*/ CBLC4Doc getC4doc() {
+    CBLC4Doc getC4doc() {
         return c4doc;
     }
 
-    /*package*/ Database getDatabase() {
+    Database getDatabase() {
         return database;
     }
 }

--- a/shared/src/main/java/com/couchbase/lite/Conflict.java
+++ b/shared/src/main/java/com/couchbase/lite/Conflict.java
@@ -4,12 +4,11 @@ package com.couchbase.lite;
  * Provides details about a Conflict.
  */
 public class Conflict {
-
     private ReadOnlyDocument mine;
     private ReadOnlyDocument theirs;
     private ReadOnlyDocument base;
 
-    /* package */ Conflict(ReadOnlyDocument mine, ReadOnlyDocument theirs, ReadOnlyDocument base) {
+    Conflict(ReadOnlyDocument mine, ReadOnlyDocument theirs, ReadOnlyDocument base) {
         this.mine = mine;
         this.theirs = theirs;
         this.base = base;

--- a/shared/src/main/java/com/couchbase/lite/CouchbaseLiteRuntimeException.java
+++ b/shared/src/main/java/com/couchbase/lite/CouchbaseLiteRuntimeException.java
@@ -1,24 +1,8 @@
-/**
- * Copyright (c) 2017 Couchbase, Inc. All rights reserved.
- * <p>
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
- * except in compliance with the License. You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions
- * and limitations under the License.
- */
 package com.couchbase.lite;
 
 import java.util.Map;
 
-/**
- * A CouchbaseLiteException gets raised whenever a Couchbase Lite faces errors.
- */
-public final class CouchbaseLiteException extends Exception {
+public final class CouchbaseLiteRuntimeException extends RuntimeException {
 
     private static final String[] DOMAINS = {
             null,
@@ -39,7 +23,7 @@ public final class CouchbaseLiteException extends Exception {
      *
      * @param message the detail message.
      */
-    public CouchbaseLiteException(String message) {
+    public CouchbaseLiteRuntimeException(String message) {
         super(message);
         this.domain = 0;
         this.code = 0;
@@ -51,7 +35,7 @@ public final class CouchbaseLiteException extends Exception {
      *
      * @param cause the cause
      */
-    public CouchbaseLiteException(Throwable cause) {
+    public CouchbaseLiteRuntimeException(Throwable cause) {
         super(cause);
         this.domain = 0;
         this.code = 0;
@@ -64,7 +48,7 @@ public final class CouchbaseLiteException extends Exception {
      * @param domain the error domain
      * @param code   the error code
      */
-    public CouchbaseLiteException(int domain, int code) {
+    public CouchbaseLiteRuntimeException(int domain, int code) {
         super();
         this.domain = domain;
         this.code = code;
@@ -78,14 +62,14 @@ public final class CouchbaseLiteException extends Exception {
      * @param code   the error code
      * @param cause  the cause
      */
-    public CouchbaseLiteException(int domain, int code, Throwable cause) {
+    public CouchbaseLiteRuntimeException(int domain, int code, Throwable cause) {
         super(cause);
         this.domain = domain;
         this.code = code;
         this.info = null;
     }
 
-    public CouchbaseLiteException(int domain, int code, Map<String, Object> info) {
+    public CouchbaseLiteRuntimeException(int domain, int code, Map<String, Object> info) {
         super();
         this.domain = domain;
         this.code = code;
@@ -128,7 +112,7 @@ public final class CouchbaseLiteException extends Exception {
     @Override
     public String toString() {
         if (domain > 0 && code > 0)
-            return "CouchbaseLiteException{" +
+            return "CouchbaseLiteRuntimeException{" +
                     "domain=" + domain +
                     ", code=" + code +
                     '}';

--- a/shared/src/main/java/com/couchbase/lite/DataSource.java
+++ b/shared/src/main/java/com/couchbase/lite/DataSource.java
@@ -89,15 +89,15 @@ public class DataSource {
     // Package level access
     //---------------------------------------------
 
-    /* package */ Object getSource() {
+    Object getSource() {
         return this.source;
     }
 
-    /* package */  String getAlias() {
+    String getAlias() {
         return alias;
     }
 
-    /* package */ Map<String, Object> asJSON() {
+    Map<String, Object> asJSON() {
         Map<String, Object> json = new HashMap<>();
         if (alias != null)
             json.put("AS", alias);

--- a/shared/src/main/java/com/couchbase/lite/Database.java
+++ b/shared/src/main/java/com/couchbase/lite/Database.java
@@ -500,7 +500,7 @@ public final class Database {
 
     void mustBeOpen() {
         if (c4db == null)
-            throw new CouchbaseLiteRuntimeException("Database is not open.");
+            throw new IllegalStateException("Database is not open.");
     }
 
     /**

--- a/shared/src/main/java/com/couchbase/lite/DatabaseChange.java
+++ b/shared/src/main/java/com/couchbase/lite/DatabaseChange.java
@@ -10,7 +10,7 @@ public class DatabaseChange {
     final private List<String> documentIDs;
     final private Database database;
 
-    /* package */ DatabaseChange(Database database, List<String> documentIDs/*, long lastSequence, boolean external*/) {
+    DatabaseChange(Database database, List<String> documentIDs/*, long lastSequence, boolean external*/) {
         this.database = database;
         // make List unmodifiable
         this.documentIDs = Collections.unmodifiableList(documentIDs);

--- a/shared/src/main/java/com/couchbase/lite/DefaultConflictResolver.java
+++ b/shared/src/main/java/com/couchbase/lite/DefaultConflictResolver.java
@@ -1,7 +1,8 @@
 package com.couchbase.lite;
 
-/*package*/ class DefaultConflictResolver implements ConflictResolver {
+class DefaultConflictResolver implements ConflictResolver {
     private static final String TAG = Log.DATABASE;
+
     /**
      * Default resolution algorithm is "most active wins", i.e. higher generation number.
      * If they are same generation, mine should win.

--- a/shared/src/main/java/com/couchbase/lite/Dictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/Dictionary.java
@@ -55,7 +55,7 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
         set(dictionary);
     }
 
-    /* package */ Dictionary(CBLFLDict data) {
+    Dictionary(CBLFLDict data) {
         super(data);
     }
 
@@ -214,7 +214,8 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
     }
 
     /**
-     * Gets a property's value as a String. Returns null if the value doesn't exist, or its value is not a String.
+     * Gets a property's value as a String.
+     * Returns null if the value doesn't exist, or its value is not a String.
      *
      * @param key the key
      * @return the String or null.
@@ -225,7 +226,8 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
     }
 
     /**
-     * Gets a property's value as a Number. Returns null if the value doesn't exist, or its value is not a Number.
+     * Gets a property's value as a Number.
+     * Returns null if the value doesn't exist, or its value is not a Number.
      *
      * @param key the key
      * @return the Number or nil.
@@ -447,7 +449,7 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
     //---------------------------------------------
     // Package level access
     //---------------------------------------------
-    /* package */boolean isChanged() {
+    boolean isChanged() {
         return changed;
     }
 
@@ -456,8 +458,7 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
      *
      * @return
      */
-    /* package */boolean isEmpty() {
-
+    boolean isEmpty() {
         /*
          -- Remove name field: data structure --
          fleece ["name": "pasin", "address": "1 street"]
@@ -487,8 +488,7 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
     // #pragma mark - FLEECE ENCODABLE
 
     // FleeceEncodable implementation
-    /* package */
-    public void fleeceEncode(FLEncoder encoder, Database database) throws CouchbaseLiteException {
+    public void fleeceEncode(FLEncoder encoder, Database database) {
         List<String> keys = getKeys();
         encoder.beginDict(keys.size());
         for (String key : keys) {
@@ -517,7 +517,8 @@ public class Dictionary extends ReadOnlyDictionary implements DictionaryInterfac
 
     private List<String> allKeys() {
         if (keys == null) {
-            List<String> result = map != null ? new ArrayList<>(map.keySet()) : new ArrayList<String>();
+            List<String> result = map != null ? new ArrayList<>(map.keySet()) :
+                    new ArrayList<String>();
             for (String key : super.getKeys()) {
                 if (!result.contains(key))
                     result.add(key);

--- a/shared/src/main/java/com/couchbase/lite/DictionaryInterface.java
+++ b/shared/src/main/java/com/couchbase/lite/DictionaryInterface.java
@@ -2,7 +2,7 @@ package com.couchbase.lite;
 
 import java.util.Map;
 
-/* package */ interface DictionaryInterface extends ReadOnlyDictionaryInterface {
+interface DictionaryInterface extends ReadOnlyDictionaryInterface {
     DictionaryInterface set(String key, Object value);
 
     DictionaryInterface remove(String key);

--- a/shared/src/main/java/com/couchbase/lite/Document.java
+++ b/shared/src/main/java/com/couchbase/lite/Document.java
@@ -93,12 +93,12 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
         set(dictionary);
     }
 
-    /*package*/Document(Database database, String documentID, CBLC4Doc c4doc, CBLFLDict data) {
+    Document(Database database, String documentID, CBLC4Doc c4doc, CBLFLDict data) {
         super(database, documentID, c4doc, data);
         this.dictionary = new Dictionary();
     }
 
-    /*package*/ Document(Database database, String documentID, boolean mustExist) throws CouchbaseLiteException {
+    Document(Database database, String documentID, boolean mustExist) {
         super(database, documentID, mustExist);
     }
 
@@ -209,7 +209,8 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
     }
 
     /**
-     * Gets a property's value as a String. Returns null if the value doesn't exist, or its value is not a String.
+     * Gets a property's value as a String.
+     * Returns null if the value doesn't exist, or its value is not a String.
      *
      * @param key the key
      * @return the String or null.
@@ -220,7 +221,8 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
     }
 
     /**
-     * Gets a property's value as a Number. Returns null if the value doesn't exist, or its value is not a Number.
+     * Gets a property's value as a Number.
+     * Returns null if the value doesn't exist, or its value is not a Number.
      *
      * @param key the key
      * @return the Number or nil.
@@ -335,7 +337,8 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
 
     /**
      * Tests whether a property exists or not.
-     * This can be less expensive than getObject(String), because it does not have to allocate an Object for the property value.
+     * This can be less expensive than getObject(String),
+     * because it does not have to allocate an Object for the property value.
      *
      * @param key the key
      * @return the boolean value representing whether a property exists or not.
@@ -350,7 +353,7 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
     //---------------------------------------------
     // Sets c4doc and updates my root dictionary
     @Override
-    protected void setC4Doc(CBLC4Doc c4doc) throws CouchbaseLiteException {
+    protected void setC4Doc(CBLC4Doc c4doc) {
         super.setC4Doc(c4doc);
         // Update delegate dictionary:
         this.dictionary = new Dictionary(getData());
@@ -360,15 +363,15 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
     // Package level access
     //---------------------------------------------
 
-    /*package*/ void save() throws CouchbaseLiteException {
+    void save() throws CouchbaseLiteException {
         save(effectiveConflictResolver(), false);
     }
 
-    /*package*/  void delete() throws CouchbaseLiteException {
+    void delete() throws CouchbaseLiteException {
         save(effectiveConflictResolver(), true);
     }
 
-    /*package*/  void purge() throws CouchbaseLiteException {
+    void purge() throws CouchbaseLiteException {
         if (!exists())
             throw new CouchbaseLiteException(Status.CBLErrorDomain, Status.NotFound);
 
@@ -391,25 +394,25 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
     }
 
     @Override
-    /*package*/ boolean isEmpty() {
+    boolean isEmpty() {
         return dictionary.isEmpty();
     }
 
     @Override
-    /* package */ long generation() {
+    long generation() {
         return super.generation() + (isChanged() ? 1 : 0);
     }
 
     // #pragma mark - FLEECE ENCODING
 
     @Override
-    /*package*/ byte[] encode() {
+    byte[] encode() {
         FLEncoder encoder = getDatabase().getC4Database().createFleeceEncoder();
         try {
             dictionary.fleeceEncode(encoder, getDatabase());
             return encoder.finish();
         } catch (LiteCoreException e) {
-            throw LiteCoreBridge.convertException(e);
+            throw LiteCoreBridge.convertRuntimeException(e);
         } finally {
             encoder.free();
         }
@@ -417,7 +420,6 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
     //---------------------------------------------
     // Private (in class only)
     //---------------------------------------------
-
 
     private void save(ConflictResolver resolver, boolean deletion) throws CouchbaseLiteException {
         if (deletion && !exists())
@@ -487,7 +489,8 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
             resolved = current;
         } else {
             // Call the custom conflict resolver
-            ReadOnlyDocument base = new ReadOnlyDocument(getDatabase(), getId(), super.getC4doc(), super.getData());
+            ReadOnlyDocument base = new ReadOnlyDocument(
+                    getDatabase(), getId(), super.getC4doc(), super.getData());
             Conflict conflict = new Conflict(this, current, base);
             resolved = resolver.resolve(conflict);
             if (resolved == null) {
@@ -509,8 +512,7 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
     }
 
     // Lower-level save method. On conflict, returns YES but sets *outDoc to NULL. */
-    private com.couchbase.litecore.Document save(boolean deletion)
-            throws LiteCoreException, IllegalStateException {
+    private com.couchbase.litecore.Document save(boolean deletion) throws LiteCoreException {
 
         // history
         List<String> revIDs = new ArrayList<>();
@@ -533,7 +535,8 @@ public final class Document extends ReadOnlyDocument implements DictionaryInterf
 
         // TODO: Refactor: use c4doc_update or c4doc_create
         // Save to database:
-        return getDatabase().getC4Database().put(getId(), body, false, false, history, revFlags, true, 0);
+        return getDatabase().getC4Database().put(
+                getId(), body, false, false, history, revFlags, true, 0);
     }
 
     private boolean isChanged() {

--- a/shared/src/main/java/com/couchbase/lite/DocumentChange.java
+++ b/shared/src/main/java/com/couchbase/lite/DocumentChange.java
@@ -20,7 +20,7 @@ package com.couchbase.lite;
 public class DocumentChange {
     private final String documentID;
 
-    /* package */ DocumentChange(String documentID) {
+    DocumentChange(String documentID) {
         this.documentID = documentID;
     }
 

--- a/shared/src/main/java/com/couchbase/lite/Expression.java
+++ b/shared/src/main/java/com/couchbase/lite/Expression.java
@@ -608,7 +608,7 @@ public abstract class Expression {
         private Object operand;
         private OpType type;
 
-        /* package */ UnaryExpression(Object operand, OpType type) {
+        UnaryExpression(Object operand, OpType type) {
             if (operand == null)
                 throw new AssertionError("operand is null.");
             this.operand = operand;

--- a/shared/src/main/java/com/couchbase/lite/FleeceEncodable.java
+++ b/shared/src/main/java/com/couchbase/lite/FleeceEncodable.java
@@ -3,5 +3,5 @@ package com.couchbase.lite;
 import com.couchbase.litecore.fleece.FLEncoder;
 
 interface FleeceEncodable {
-    void fleeceEncode(FLEncoder encoder, Database database) throws CouchbaseLiteException;
+    void fleeceEncode(FLEncoder encoder, Database database);
 }

--- a/shared/src/main/java/com/couchbase/lite/FullTextQueryRow.java
+++ b/shared/src/main/java/com/couchbase/lite/FullTextQueryRow.java
@@ -38,7 +38,7 @@ public class FullTextQueryRow extends QueryRow {
     // constructors
     //---------------------------------------------
 
-    /* package */ FullTextQueryRow(Query query, C4QueryEnumerator c4enum) {
+    FullTextQueryRow(Query query, C4QueryEnumerator c4enum) {
         super(query, c4enum);
         this.matchCount = (int) c4enum.getFullTextTermCount();
         if (this.matchCount > 0) {

--- a/shared/src/main/java/com/couchbase/lite/IndexType.java
+++ b/shared/src/main/java/com/couchbase/lite/IndexType.java
@@ -33,12 +33,11 @@ public enum IndexType {
 
     private int value;
 
-    /* package */ IndexType(int value) {
+    IndexType(int value) {
         this.value = value;
     }
 
-    /* package */ int getValue() {
+    int getValue() {
         return value;
     }
 }
-

--- a/shared/src/main/java/com/couchbase/lite/LiveQuery.java
+++ b/shared/src/main/java/com/couchbase/lite/LiveQuery.java
@@ -33,7 +33,7 @@ public class LiveQuery implements DatabaseChangeListener {
     // Constructors
     //---------------------------------------------
 
-    /* package */ LiveQuery(Query query) {
+    LiveQuery(Query query) {
         if (query == null)
             throw new IllegalArgumentException("query should not be null.");
 

--- a/shared/src/main/java/com/couchbase/lite/LiveQueryChange.java
+++ b/shared/src/main/java/com/couchbase/lite/LiveQueryChange.java
@@ -12,7 +12,7 @@ public class LiveQueryChange {
     // constructors
     //---------------------------------------------
 
-    /*package*/ LiveQueryChange(LiveQuery query, ResultSet rows, Throwable error) {
+    LiveQueryChange(LiveQuery query, ResultSet rows, Throwable error) {
         this.query = query;
         this.rows = rows;
         this.error = error;

--- a/shared/src/main/java/com/couchbase/lite/Log.java
+++ b/shared/src/main/java/com/couchbase/lite/Log.java
@@ -101,7 +101,6 @@ public class Log {
      *                 is passed as a paremeter, it will return true.
      * @return boolean indicating whether logging is enabled.
      */
-    /* package */
     static boolean isLoggingEnabled(String tag, int logLevel) {
 
         // this hashmap lookup might be a little expensive, and so it might make

--- a/shared/src/main/java/com/couchbase/lite/Query.java
+++ b/shared/src/main/java/com/couchbase/lite/Query.java
@@ -226,7 +226,7 @@ public class Query {
     // Private (in class only)
     //---------------------------------------------
 
-    private void check() throws CouchbaseLiteException, IllegalStateException {
+    private void check() throws CouchbaseLiteException {
         database = (Database) from.getSource();
         String json = encodeAsJSON();
         Log.v(TAG, "Query encoded as %s", json);

--- a/shared/src/main/java/com/couchbase/lite/QueryRow.java
+++ b/shared/src/main/java/com/couchbase/lite/QueryRow.java
@@ -35,7 +35,7 @@ public class QueryRow {
     // constructors
     //---------------------------------------------
 
-    /* package */ QueryRow(Query query, C4QueryEnumerator c4enum) {
+    QueryRow(Query query, C4QueryEnumerator c4enum) {
         this.query = query;
         this.c4enum = c4enum;
         this.documentID = c4enum.getDocID();

--- a/shared/src/main/java/com/couchbase/lite/Range.java
+++ b/shared/src/main/java/com/couchbase/lite/Range.java
@@ -26,7 +26,7 @@ public class Range {
     private int location;
     private int length;
 
-    /* package */ Range(int location, int length) {
+    Range(int location, int length) {
         this.location = location;
         this.length = length;
     }

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyArray.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyArray.java
@@ -26,7 +26,7 @@ public class ReadOnlyArray implements ReadOnlyArrayInterface, FleeceEncodable {
     // Constructors
     //---------------------------------------------
 
-    /* package */ ReadOnlyArray(CBLFLArray data) {
+    ReadOnlyArray(CBLFLArray data) {
         setData(data);
     }
 
@@ -89,7 +89,7 @@ public class ReadOnlyArray implements ReadOnlyArrayInterface, FleeceEncodable {
      */
     @Override
     public int getInt(int index) {
-        return (int)fleeceValue(index).asInt();
+        return (int) fleeceValue(index).asInt();
     }
 
     /**

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyArrayInterface.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyArrayInterface.java
@@ -3,7 +3,7 @@ package com.couchbase.lite;
 import java.util.Date;
 import java.util.List;
 
-/* package */ interface ReadOnlyArrayInterface extends Iterable<Object> {
+interface ReadOnlyArrayInterface extends Iterable<Object> {
     int count();
 
     Object getObject(int index);

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionary.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionary.java
@@ -32,7 +32,7 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
     // Constructors
     //-------------------------------------------------------------------------
 
-    /* package */ ReadOnlyDictionary(CBLFLDict data) {
+    ReadOnlyDictionary(CBLFLDict data) {
         setData(data);
     }
 
@@ -105,7 +105,7 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
     @Override
     public int getInt(String key) {
         FLValue value = fleeceValue(key);
-        return value != null ? (int)value.asInt() : 0;
+        return value != null ? (int) value.asInt() : 0;
     }
 
     /**
@@ -270,7 +270,7 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
 
     // FleeceEncodable implementation
     @Override
-    public void fleeceEncode(FLEncoder encoder, Database database) throws CouchbaseLiteException {
+    public void fleeceEncode(FLEncoder encoder, Database database) {
         encoder.writeValue(flDict);
     }
 
@@ -285,7 +285,7 @@ public class ReadOnlyDictionary implements ReadOnlyDictionaryInterface, FleeceEn
     //---------------------------------------------
     // Package
     //---------------------------------------------
-    /* package */boolean isEmpty() {
+    boolean isEmpty() {
         return count() == 0;
     }
     //---------------------------------------------

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionaryInterface.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyDictionaryInterface.java
@@ -4,7 +4,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-/* package */ interface ReadOnlyDictionaryInterface extends Iterable<String> {
+interface ReadOnlyDictionaryInterface extends Iterable<String> {
     int count();
 
     List<String> getKeys();

--- a/shared/src/main/java/com/couchbase/lite/ReadOnlyDocument.java
+++ b/shared/src/main/java/com/couchbase/lite/ReadOnlyDocument.java
@@ -180,7 +180,7 @@ public class ReadOnlyDocument extends ReadOnlyDictionary {
                 new DefaultConflictResolver();
     }
 
-    boolean selectConflictingRevision() throws CouchbaseLiteException {
+    boolean selectConflictingRevision() {
         try {
             if (!c4doc.getRawDoc().selectNextLeaf(false, true))
                 return false;
@@ -192,8 +192,7 @@ public class ReadOnlyDocument extends ReadOnlyDictionary {
         return true;
     }
 
-    boolean selectCommonAncestor(ReadOnlyDocument doc1, ReadOnlyDocument doc2)
-            throws CouchbaseLiteException {
+    boolean selectCommonAncestor(ReadOnlyDocument doc1, ReadOnlyDocument doc2) {
         if (!c4doc.getRawDoc().selectCommonAncestorRevision(doc1.getRevID(), doc2.getRevID()))
             return false;
         setC4Doc(c4doc); // self.c4Doc = _c4Doc; // This will update to the selected revision

--- a/shared/src/main/java/com/couchbase/lite/Replicator.java
+++ b/shared/src/main/java/com/couchbase/lite/Replicator.java
@@ -46,7 +46,7 @@ public class Replicator implements NetworkReachabilityListener {
          */
         STOPPED(0),
         /**
-         * The replication is unactive; either waiting for changes or offline as the remote host is
+         * The replication is inactive; either waiting for changes or offline as the remote host is
          * unreachable.
          */
         IDLE(1),
@@ -57,11 +57,11 @@ public class Replicator implements NetworkReachabilityListener {
 
         private int value;
 
-        /* package */ ActivityLevel(int value) {
+        ActivityLevel(int value) {
             this.value = value;
         }
 
-        /* package */ int getValue() {
+        int getValue() {
             return value;
         }
     }
@@ -104,7 +104,7 @@ public class Replicator implements NetworkReachabilityListener {
             return total;
         }
 
-        /*package*/ Progress copy() {
+        Progress copy() {
             return new Progress(completed, total);
         }
     }
@@ -146,7 +146,7 @@ public class Replicator implements NetworkReachabilityListener {
         }
 
 
-        /*package*/ Status copy() {
+        Status copy() {
             return new Status(activityLevel, progress.copy());
         }
     }

--- a/shared/src/main/java/com/couchbase/lite/ReplicatorChangeListener.java
+++ b/shared/src/main/java/com/couchbase/lite/ReplicatorChangeListener.java
@@ -6,4 +6,3 @@ package com.couchbase.lite;
 public interface ReplicatorChangeListener {
     void changed(Replicator replicator, Replicator.Status status, CouchbaseLiteException error);
 }
-

--- a/shared/src/main/java/com/couchbase/lite/ReplicatorConfiguration.java
+++ b/shared/src/main/java/com/couchbase/lite/ReplicatorConfiguration.java
@@ -195,7 +195,7 @@ public class ReplicatorConfiguration {
     // Package level access
     //---------------------------------------------
 
-    /*package*/ Map<String, Object> effectiveOptions() {
+    Map<String, Object> effectiveOptions() {
         Map<String, Object> options = new HashMap<>();
 
         String username = getUsername();
@@ -222,11 +222,11 @@ public class ReplicatorConfiguration {
         return options;
     }
 
-    /*package*/URI getTargetURI() {
+    URI getTargetURI() {
         return target instanceof URI ? (URI) target : null;
     }
 
-    /*package*/Database getTargetDatabase() {
+    Database getTargetDatabase() {
         return target instanceof Database ? (Database) target : null;
     }
 

--- a/shared/src/main/java/com/couchbase/lite/ResultSet.java
+++ b/shared/src/main/java/com/couchbase/lite/ResultSet.java
@@ -38,7 +38,7 @@ public class ResultSet {
     // constructors
     //---------------------------------------------
 
-    /* package */ ResultSet(Query query, C4QueryEnumerator c4enum) {
+    ResultSet(Query query, C4QueryEnumerator c4enum) {
         this.query = query;
         this.c4enum = c4enum;
         Log.v(TAG, "Beginning query enumeration (%p)", c4enum);
@@ -85,7 +85,7 @@ public class ResultSet {
     // Package level access
     //---------------------------------------------
 
-    /*package*/void release() {
+    void release() {
         if (c4enum != null) {
             c4enum.close();
             c4enum.free();
@@ -93,7 +93,7 @@ public class ResultSet {
         }
     }
 
-    /*package*/ResultSet refresh() throws CouchbaseLiteException {
+    ResultSet refresh() throws CouchbaseLiteException {
         if (query == null) return null;
         try {
             C4QueryEnumerator newEnum = c4enum.refresh();
@@ -103,7 +103,7 @@ public class ResultSet {
         }
     }
 
-    /*package*/int getRowCount() {
+    int getRowCount() throws CouchbaseLiteException {
         try {
             return (int) c4enum.getRowCount();
         } catch (LiteCoreException e) {
@@ -111,7 +111,7 @@ public class ResultSet {
         }
     }
 
-    /*package*/boolean isValidEnumerator() {
+    boolean isValidEnumerator() {
         return c4enum != null && !c4enum.isClosed();
     }
 }

--- a/shared/src/main/java/com/couchbase/lite/Status.java
+++ b/shared/src/main/java/com/couchbase/lite/Status.java
@@ -1,6 +1,6 @@
 package com.couchbase.lite;
 
-/*package*/ interface Status {
+interface Status {
     int CBLErrorDomain = 1000;
 
     int Forbidden = 403;

--- a/shared/src/main/java/com/couchbase/lite/internal/bridge/LiteCoreBridge.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/bridge/LiteCoreBridge.java
@@ -14,10 +14,15 @@
 package com.couchbase.lite.internal.bridge;
 
 import com.couchbase.lite.CouchbaseLiteException;
+import com.couchbase.lite.CouchbaseLiteRuntimeException;
 import com.couchbase.litecore.LiteCoreException;
 
 public class LiteCoreBridge {
     public static CouchbaseLiteException convertException(LiteCoreException orgEx) {
         return new CouchbaseLiteException(orgEx.domain, orgEx.code, orgEx);
+    }
+
+    public static CouchbaseLiteRuntimeException convertRuntimeException(LiteCoreException orgEx) {
+        return new CouchbaseLiteRuntimeException(orgEx.domain, orgEx.code, orgEx);
     }
 }


### PR DESCRIPTION
…or Exception

- Make CouchbaseLiteException extended from Exception instead of Runtime.
- Introduced CouchbaseLiteRuntimeException which could be thrown by inappropriate  codes
- API spec which has `thrown` keywords throws CouchbaseLiteException, others could throw CouchbaseLiteRuntimeException.

- In addition, removed /* package */ comment.
- some code formating.