### PR TITLE
Fixed #1201 - Thread safety for Database instance.

### DIFF
--- a/android/CouchbaseLite/src/androidTest/assets/test.properties
+++ b/android/CouchbaseLite/src/androidTest/assets/test.properties
@@ -1,5 +1,6 @@
 # properties file for unit test
 replicatorTestsEnabled=false
+threadTestsEnabled=false
 remoteHost=10.0.2.2
 remotePort=4984
 remoteDB=db

--- a/android/CouchbaseLite/src/androidTest/assets/test.properties
+++ b/android/CouchbaseLite/src/androidTest/assets/test.properties
@@ -1,6 +1,6 @@
 # properties file for unit test
 replicatorTestsEnabled=false
-threadTestsEnabled=false
+concurrentTestsEnabled=false
 remoteHost=10.0.2.2
 remotePort=4984
 remoteDB=db

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -378,7 +378,7 @@ public class DatabaseTest extends BaseTest {
         try {
             Document doc = db.getDocument("doc1");
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should be thrown IllegalStateException!!
         }
     }
@@ -393,7 +393,7 @@ public class DatabaseTest extends BaseTest {
         try {
             Document doc = db.getDocument("doc1");
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should be thrown IllegalStateException!!
         }
     }
@@ -529,7 +529,7 @@ public class DatabaseTest extends BaseTest {
         try {
             save(doc);
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should be thrown IllegalStateException!!
         }
     }
@@ -545,7 +545,7 @@ public class DatabaseTest extends BaseTest {
         try {
             save(doc);
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should be thrown IllegalStateException!!
         }
     }
@@ -693,7 +693,7 @@ public class DatabaseTest extends BaseTest {
         try {
             db.delete(doc);
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should be thrown IllegalStateException!!
         }
     }
@@ -710,7 +710,7 @@ public class DatabaseTest extends BaseTest {
         try {
             db.delete(doc);
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should be thrown IllegalStateException!!
         }
     }
@@ -851,7 +851,7 @@ public class DatabaseTest extends BaseTest {
         try {
             db.purge(doc);
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should be thrown IllegalStateException!!
         }
     }
@@ -868,7 +868,7 @@ public class DatabaseTest extends BaseTest {
         try {
             db.purge(doc);
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should be thrown IllegalStateException!!
         }
     }
@@ -957,7 +957,7 @@ public class DatabaseTest extends BaseTest {
         try {
             deleteDatabase(db);
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should come here!
         }
     }
@@ -979,7 +979,7 @@ public class DatabaseTest extends BaseTest {
         try {
             db.delete();
             fail();
-        } catch (IllegalStateException e) {
+        } catch (CouchbaseLiteRuntimeException e) {
             // should come here!
         }
         assertFalse(path.exists());

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/utils/Config.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/utils/Config.java
@@ -19,6 +19,10 @@ public class Config extends java.util.Properties {
         return Boolean.parseBoolean(getProperty("replicatorTestsEnabled"));
     }
 
+    public boolean threadTestsEnabled() {
+        return Boolean.parseBoolean(getProperty("threadTestsEnabled"));
+    }
+
     public String remoteHost() {
         return getProperty("remoteHost");
     }

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/utils/Config.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/utils/Config.java
@@ -19,8 +19,8 @@ public class Config extends java.util.Properties {
         return Boolean.parseBoolean(getProperty("replicatorTestsEnabled"));
     }
 
-    public boolean threadTestsEnabled() {
-        return Boolean.parseBoolean(getProperty("threadTestsEnabled"));
+    public boolean concurrentTestsEnabled() {
+        return Boolean.parseBoolean(getProperty("concurrentTestsEnabled"));
     }
 
     public String remoteHost() {

--- a/shared/src/main/java/com/couchbase/lite/BaseDatabaseConfiguration.java
+++ b/shared/src/main/java/com/couchbase/lite/BaseDatabaseConfiguration.java
@@ -81,8 +81,4 @@ public class BaseDatabaseConfiguration {
         this.conflictResolver = conflictResolver;
         return this;
     }
-
-    //---------------------------------------------
-    // Package level access
-    //---------------------------------------------
 }

--- a/shared/src/main/java/com/couchbase/lite/CouchbaseLiteException.java
+++ b/shared/src/main/java/com/couchbase/lite/CouchbaseLiteException.java
@@ -99,6 +99,21 @@ public final class CouchbaseLiteException extends Exception {
         this.info = null;
     }
 
+    /**
+     * Constructs a new exception with the specified error domain, error code and the specified cause
+     *
+     * @param message the detail message
+     * @param cause   the cause
+     * @param domain  the error domain
+     * @param code    the error code
+     */
+    public CouchbaseLiteException(String message, Throwable cause, int domain, int code) {
+        super(message, cause);
+        this.domain = domain;
+        this.code = code;
+        this.info = null;
+    }
+
     public CouchbaseLiteException(int domain, int code, Map<String, Object> info) {
         super();
         this.domain = domain;
@@ -145,6 +160,7 @@ public final class CouchbaseLiteException extends Exception {
             return "CouchbaseLiteException{" +
                     "domain=" + domain +
                     ", code=" + code +
+                    ", msg=" + super.getMessage() +
                     '}';
         else
             return super.toString();

--- a/shared/src/main/java/com/couchbase/lite/CouchbaseLiteRuntimeException.java
+++ b/shared/src/main/java/com/couchbase/lite/CouchbaseLiteRuntimeException.java
@@ -58,12 +58,27 @@ public final class CouchbaseLiteRuntimeException extends RuntimeException {
     /**
      * Constructs a new exception with the specified error domain, error code and the specified cause
      *
-     * @param domain the error domain
-     * @param code   the error code
-     * @param cause  the cause
+     * @param message the detail message.
+     * @param cause   the cause
+     * @param domain  the error domain
+     * @param code    the error code
      */
-    public CouchbaseLiteRuntimeException(int domain, int code, Throwable cause) {
-        super(cause);
+    public CouchbaseLiteRuntimeException(String message, Throwable cause, int domain, int code) {
+        super(message, cause);
+        this.domain = domain;
+        this.code = code;
+        this.info = null;
+    }
+
+    /**
+     * Constructs a new exception with the specified error domain, error code and the specified cause
+     *
+     * @param message the detail message.
+     * @param domain  the error domain
+     * @param code    the error code
+     */
+    public CouchbaseLiteRuntimeException(String message, int domain, int code) {
+        super(message);
         this.domain = domain;
         this.code = code;
         this.info = null;
@@ -115,6 +130,7 @@ public final class CouchbaseLiteRuntimeException extends RuntimeException {
             return "CouchbaseLiteRuntimeException{" +
                     "domain=" + domain +
                     ", code=" + code +
+                    ", msg=" + super.getMessage() +
                     '}';
         else
             return super.toString();

--- a/shared/src/main/java/com/couchbase/lite/internal/bridge/LiteCoreBridge.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/bridge/LiteCoreBridge.java
@@ -19,10 +19,10 @@ import com.couchbase.litecore.LiteCoreException;
 
 public class LiteCoreBridge {
     public static CouchbaseLiteException convertException(LiteCoreException orgEx) {
-        return new CouchbaseLiteException(orgEx.domain, orgEx.code, orgEx);
+        return new CouchbaseLiteException(orgEx.getMessage(), orgEx, orgEx.domain, orgEx.code);
     }
 
     public static CouchbaseLiteRuntimeException convertRuntimeException(LiteCoreException orgEx) {
-        return new CouchbaseLiteRuntimeException(orgEx.domain, orgEx.code, orgEx);
+        return new CouchbaseLiteRuntimeException(orgEx.getMessage(), orgEx, orgEx.domain, orgEx.code);
     }
 }


### PR DESCRIPTION
- Database class has a lock object for synchronization.
- Synchronization should be done in public method level.
- In case DB is not open, throw CouchbaseLiteRuntimeException instead of IllegalStateException. To be consistent with case db close state problem is found in the LiteCore level.