### PR TITLE
Fixed #1321 - 2.0: Tread safety - Database (postDatabaseChanged(), po…

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConcurrentDatabaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConcurrentDatabaseTest.java
@@ -229,7 +229,6 @@ public class ConcurrentDatabaseTest extends BaseTest {
             verifyByTagName("tag-" + i, kNDocs);
     }
 
-
     @Test
     public void testConcurrentUpdate() throws InterruptedException, CouchbaseLiteException {
         if (!config.concurrentTestsEnabled())
@@ -653,10 +652,7 @@ public class ConcurrentDatabaseTest extends BaseTest {
         assertTrue(latch2.await(60, TimeUnit.SECONDS));
     }
 
-    // TODO: DatabaseChangeNotification is sent from main thread.
-    //       This code waits threads to finish on main thread. so cause deadlock.
-    //       And test fail
-    //@Test
+    @Test
     public void testBlockDatabaseChange() throws InterruptedException, CouchbaseLiteException {
         if (!config.concurrentTestsEnabled())
             return;
@@ -688,10 +684,7 @@ public class ConcurrentDatabaseTest extends BaseTest {
         assertTrue(latch2.await(10, TimeUnit.SECONDS));
     }
 
-    // TODO: DatabaseChangeNotification is sent from main thread.
-    //       This code waits threads to finish on main thread. so cause deadlock.
-    //       And test fail
-    //@Test
+    @Test
     public void testBlockDocumentChange() throws InterruptedException, CouchbaseLiteException {
         if (!config.concurrentTestsEnabled())
             return;

--- a/shared/src/main/java/com/couchbase/lite/DatabaseChange.java
+++ b/shared/src/main/java/com/couchbase/lite/DatabaseChange.java
@@ -31,4 +31,12 @@ public class DatabaseChange {
     public List<String> getDocumentIDs() {
         return documentIDs;
     }
+
+    @Override
+    public String toString() {
+        return "DatabaseChange{" +
+                "database=" + database +
+                ", documentIDs=" + documentIDs +
+                '}';
+    }
 }

--- a/shared/src/main/java/com/couchbase/lite/DocumentChange.java
+++ b/shared/src/main/java/com/couchbase/lite/DocumentChange.java
@@ -30,4 +30,11 @@ public class DocumentChange {
     public String getDocumentID() {
         return documentID;
     }
+
+    @Override
+    public String toString() {
+        return "DocumentChange{" +
+                "documentID='" + documentID + '\'' +
+                '}';
+    }
 }


### PR DESCRIPTION
…stDocumentChanged() and resolveConflictInDocument())

- resolveConflictInDocument() -> make synchronized with lock.
- postDataChanged() and postDocumentChanged() -> isolate data preparation and notification like Obj-C implementation. Data preparation is synchronized with lock.