### PR TITLE
Fixed #1346 - 2.0 SessionAuthenticator crashing

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
@@ -322,19 +322,11 @@ public class CBLWebSocket extends C4Socket {
                 for (Map.Entry<String, Object> entry : value.asDict().entrySet())
                     builder.header(entry.getKey(), entry.getValue().toString());
             }
+
             // Cookies:
-            // NOTE: BasicAuthenticator -> FLValue (Map)
-            //       SessionAuthenticator -> String
-            Object cookieObject = options.get(kC4ReplicatorOptionCookies);
-            if (cookieObject != null) {
-                String cookieString = null;
-                if (cookieObject instanceof String)
-                    cookieString = (String) cookieObject;
-                else if (cookieObject instanceof FLValue)
-                    cookieString = ((FLValue) cookieObject).asString();
-                if (cookieString != null)
-                    builder.addHeader("Cookie", cookieString);
-            }
+            String cookieString = (String) options.get(kC4ReplicatorOptionCookies);
+            if (cookieString != null)
+                builder.addHeader("Cookie", cookieString);
         }
 
         // other header values


### PR DESCRIPTION
- BasicAuthentication does not enter this cookie logic. And also cookie values are already converted to Java class. So return value from options Map should be String here.