### PR TITLE
Fixed #1393 - 2.0: Replicating the conflicted document causes unexpec…

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/Database.java
+++ b/shared/src/main/java/com/couchbase/lite/Database.java
@@ -751,9 +751,9 @@ public final class Database implements C4Constants {
                     Log.i(TAG, "Resolving doc '%s' with %s (mine=%s, theirs=%s, base=%s)",
                             docID,
                             resolver != null ? resolver.getClass().getSimpleName() : "null",
-                            doc != null ? doc.getRevID() : "null",
-                            otherDoc != null ? otherDoc.getRevID() : "null",
-                            baseDoc != null ? baseDoc.getRevID() : "null");
+                            doc != null ? doc.getSelectedRevID() : "null",
+                            otherDoc != null ? otherDoc.getSelectedRevID() : "null",
+                            baseDoc != null ? baseDoc.getSelectedRevID() : "null");
                     resolved = resolver.resolve(conflict);
                     if (resolved == null)
                         throw new CouchbaseLiteException(LiteCoreDomain, kC4ErrorConflict);
@@ -764,11 +764,11 @@ public final class Database implements C4Constants {
                 String losingRevID;
                 byte[] mergedBody = null;
                 if (resolved == otherDoc) {
-                    winningRevID = otherDoc.getRevID();
-                    losingRevID = doc.getRevID();
+                    winningRevID = otherDoc.getSelectedRevID();
+                    losingRevID = doc.getSelectedRevID();
                 } else {
-                    winningRevID = doc.getRevID();
-                    losingRevID = otherDoc.getRevID();
+                    winningRevID = doc.getSelectedRevID();
+                    losingRevID = otherDoc.getSelectedRevID();
                     if (resolved != doc) {
                         resolved.setDatabase(this);
                         mergedBody = resolved.encode();

--- a/shared/src/main/java/com/couchbase/lite/LiveQuery.java
+++ b/shared/src/main/java/com/couchbase/lite/LiveQuery.java
@@ -54,6 +54,11 @@ public class LiveQuery implements DatabaseChangeListener {
      * Starts observing database changes and reports changes in the query result.
      */
     public void run() {
+        if (query == null)
+            throw new IllegalArgumentException("query should not be null.");
+        if (query.getDatabase() == null)
+            throw new IllegalArgumentException("associated database should not be null.");
+
         observing = true;
         releaseResultSet();
         query.getDatabase().addChangeListener(this);


### PR DESCRIPTION
…ted behavior (crash).

- `ReadOnlyDocument.setC4Doc(CBL4Doc c4doc)` should not call `free()` as both given c4doc and this.c4doc point to same `C4Document` instance. It causes unexpected cleanup.