### PR TITLE
Update Unit tests for Java Core Issue 290

### DIFF
--- a/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -540,7 +540,6 @@ public class DatabaseTest extends LiteTestCaseWithDB {
             final Replication replication = database.createPullReplication(server.url("/db").url());
 
             assertEquals(0, database.getAllReplications().size());
-            assertEquals(0, database.getActiveReplications().size());
 
             final CountDownLatch replicationRunning = new CountDownLatch(1);
             replication.addChangeListener(new ReplicationRunningObserver(replicationRunning));
@@ -551,7 +550,6 @@ public class DatabaseTest extends LiteTestCaseWithDB {
             assertTrue(success);
 
             assertEquals(1, database.getAllReplications().size());
-            assertEquals(1, database.getActiveReplications().size());
 
             final CountDownLatch replicationDoneSignal = new CountDownLatch(1);
             replication.addChangeListener(new ReplicationFinishedObserver(replicationDoneSignal));
@@ -564,8 +562,7 @@ public class DatabaseTest extends LiteTestCaseWithDB {
             // need to pause briefly to let the internal change listener to update activeReplications.
             Thread.sleep(500);
 
-            assertEquals(1, database.getAllReplications().size());
-            assertEquals(0, database.getActiveReplications().size());
+            assertEquals(0, database.getAllReplications().size());
         } finally {
             server.shutdown();
         }

--- a/src/androidTest/java/com/couchbase/lite/RouterTest.java
+++ b/src/androidTest/java/com/couchbase/lite/RouterTest.java
@@ -1320,7 +1320,7 @@ public class RouterTest extends LiteTestCaseWithDB {
 
             // WAIT replicator becomes IDLE
             List<CountDownLatch> replicationIdleSignals = new ArrayList<CountDownLatch>();
-            List<Replication> repls = database.getActiveReplications();
+            List<Replication> repls = database.getAllReplications();
             for (Replication repl : repls) {
                 if (repl.getStatus() == Replication.ReplicationStatus.REPLICATION_ACTIVE) {
                     final CountDownLatch replicationIdleSignal = new CountDownLatch(1);
@@ -1344,7 +1344,7 @@ public class RouterTest extends LiteTestCaseWithDB {
 
             // WAIT replicator becomes IDLE
             replicationIdleSignals = new ArrayList<CountDownLatch>();
-            repls = database.getActiveReplications();
+            repls = database.getAllReplications();
             for (Replication repl : repls) {
                 if (repl.getStatus() == Replication.ReplicationStatus.REPLICATION_ACTIVE) {
                     final CountDownLatch replicationIdleSignal = new CountDownLatch(1);

--- a/src/androidTest/java/com/couchbase/lite/syncgateway/TenReplicationsTest.java
+++ b/src/androidTest/java/com/couchbase/lite/syncgateway/TenReplicationsTest.java
@@ -63,7 +63,7 @@ public class TenReplicationsTest extends LiteTestCaseWithDB {
         }
 
         // make sure if 10 repls are active
-        assertEquals(NUM_REPLS, database.getActiveReplications().size());
+        assertEquals(NUM_REPLS, database.getAllReplications().size());
 
         // stop all repls by repl.stop()
         for (final Replication repl : repls)


### PR DESCRIPTION
https://github.com/couchbase/couchbase-lite-java-core/issues/290

- Eliminated old `getAllReplications()` call, and replaced `getActiveReplicators()` with new `getAllReplicators()`.