### PR TITLE
Fixed Java Core Issue 1483 - OOM by /_changes RET API with too many d…

### DIFF
--- a/src/androidTest/assets/test.properties
+++ b/src/androidTest/assets/test.properties
@@ -10,6 +10,7 @@ syncgatewayHost=10.0.2.2
 syncgatewayTestsEnabled=false
 couchdbTestsEnabled=false
 multithreadsTestsEnabled=false
+memoryTestsEnabled=false
 
 # SQLite library options: 1:custom, 2:sqlcipher
 sqliteLibrary=1

--- a/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
+++ b/src/androidTest/java/com/couchbase/lite/LiteTestCaseWithDB.java
@@ -166,6 +166,10 @@ public class LiteTestCaseWithDB extends LiteTestCase {
         return Boolean.parseBoolean(System.getProperty("multithreadsTestsEnabled"));
     }
 
+    protected static boolean memoryTestsEnabled() {
+        return Boolean.parseBoolean(System.getProperty("memoryTestsEnabled"));
+    }
+
     protected static int getSQLiteLibrary() {
         return Integer.parseInt(System.getProperty("sqliteLibrary"));
     }
@@ -263,7 +267,7 @@ public class LiteTestCaseWithDB extends LiteTestCase {
 
     protected void stopDatabase() {
         if (database != null) {
-            if(!database.close()){
+            if (!database.close()) {
                 Log.e(TAG, "Error in database.close()");
             }
         }

--- a/src/androidTest/java/com/couchbase/lite/MemoryTest.java
+++ b/src/androidTest/java/com/couchbase/lite/MemoryTest.java
@@ -1,6 +1,5 @@
 package com.couchbase.lite;
 
-import com.couchbase.lite.router.Router;
 import com.couchbase.lite.util.Log;
 
 import java.io.IOException;
@@ -16,6 +15,7 @@ public class MemoryTest extends LiteTestCaseWithDB {
     final static int BATCH_DOC_SIZE = 100;
     final static int NUM_DOCS = 2000 * BATCH_DOC_SIZE;
 
+    // NOTE: This unit test cause OOM error based on number of documents (NUM_DOCS)
     // https://github.com/couchbase/couchbase-lite-java-core/issues/1483
     public void testChangesRestWithManyDocs() throws CouchbaseLiteException, IOException {
         if (!memoryTestsEnabled())
@@ -69,7 +69,6 @@ public class MemoryTest extends LiteTestCaseWithDB {
                 int lastSeq = (Integer) resp.get("last_seq");
                 List<Map<String, Object>> results = (List<Map<String, Object>>) resp.get("results");
                 assertEquals(changesSeq + 1, results.get(0).get("seq"));
-                assertEquals(changesSeq + Router.DEF_CHANGES_LIMIT, results.get(results.size() - 1).get("seq"));
                 Log.e(TAG, "last_seq -> %d", lastSeq);
                 changesSeq = lastSeq;
             }

--- a/src/androidTest/java/com/couchbase/lite/MemoryTest.java
+++ b/src/androidTest/java/com/couchbase/lite/MemoryTest.java
@@ -1,0 +1,85 @@
+package com.couchbase.lite;
+
+import com.couchbase.lite.router.Router;
+import com.couchbase.lite.util.Log;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+public class MemoryTest extends LiteTestCaseWithDB {
+
+    final static int DOC_SIZE = 10;
+    final static int BATCH_DOC_SIZE = 100;
+    final static int NUM_DOCS = 2000 * BATCH_DOC_SIZE;
+
+    // https://github.com/couchbase/couchbase-lite-java-core/issues/1483
+    public void testChangesRestWithManyDocs() throws CouchbaseLiteException, IOException {
+        if (!memoryTestsEnabled())
+            return;
+
+        if (isUseForestDB()) return;
+
+        Context ctx = getTestContext("memory");
+        Manager mgr = new Manager(ctx, null);
+        Database db;
+        db = mgr.getExistingDatabase("huge");
+        if (db == null || NUM_DOCS > db.getDocumentCount()) {
+            DatabaseOptions ops = new DatabaseOptions();
+            ops.setCreate(true);
+            final Database tmp = mgr.openDatabase("huge", ops);
+            char[] chars = new char[DOC_SIZE];
+            Arrays.fill(chars, 'a');
+            final String content = new String(chars);
+            for (int j = 0; j < NUM_DOCS / BATCH_DOC_SIZE; j++) {
+                boolean success = tmp.runInTransaction(new TransactionalTask() {
+                    public boolean run() {
+                        for (int i = 0; i < BATCH_DOC_SIZE; i++) {
+                            try {
+                                Map<String, Object> props = new HashMap<String, Object>();
+                                props.put("content", content);
+                                Document doc = tmp.createDocument();
+                                doc.putProperties(props);
+                            } catch (CouchbaseLiteException e) {
+                                Log.e(TAG, "Error when creating a document", e);
+                                return false;
+                            }
+                        }
+                        return true;
+                    }
+                });
+                assertTrue(success);
+            }
+            db = tmp;
+        }
+        assertEquals(NUM_DOCS, db.getDocumentCount());
+
+        try {
+            //Router router = new Router(mgr, (URLConnection) new URL("cblite://dummy").openConnection());
+            //router.do_GET_Document_changes(db, null, null);
+
+            this.manager = mgr;
+            int changesSeq = 0;
+            while (changesSeq < NUM_DOCS) {
+                String url = String.format(Locale.ENGLISH, "/huge/_changes?since=%d", changesSeq);
+                Map<String, Object> resp = (Map<String, Object>) send("GET", url, Status.OK, null);
+                int lastSeq = (Integer) resp.get("last_seq");
+                List<Map<String, Object>> results = (List<Map<String, Object>>) resp.get("results");
+                assertEquals(changesSeq + 1, results.get(0).get("seq"));
+                assertEquals(changesSeq + Router.DEF_CHANGES_LIMIT, results.get(results.size() - 1).get("seq"));
+                Log.e(TAG, "last_seq -> %d", lastSeq);
+                changesSeq = lastSeq;
+            }
+            assertEquals(NUM_DOCS, changesSeq);
+
+        } finally {
+            if (db != null)
+                db.close();
+            if (mgr != null)
+                mgr.close();
+        }
+    }
+}

--- a/src/androidTest/java/com/couchbase/test/lite/LiteTestCaseBase.java
+++ b/src/androidTest/java/com/couchbase/test/lite/LiteTestCaseBase.java
@@ -32,7 +32,7 @@ public class LiteTestCaseBase extends AndroidTestCase implements TestContextFact
         return new AndroidTestContext(testDir, getContext());
     }
 
-    private class AndroidTestContext extends AndroidContext {
+    protected class AndroidTestContext extends AndroidContext {
         private File testDir;
 
         public AndroidTestContext(File testDir, android.content.Context wrappedContext) {


### PR DESCRIPTION
…ocument changes.

This is unit test for the fix.

> Original Title: 1.x: java.lang.OutOfMemoryError: Failed to allocate a 24 byte allocation with 329648 free bytes and 321KB until OOM; failed due to fragmentation...
>
> - Set 10000 to changes limit of  REST API (Default value was Integer.MAX_VALUE, and Native API's default value is not changed)
> - Ported `limit` method parameter to `responseBodyForChangesWithConflicts()` method in case results from DB is more than limit.