### PR TITLE
Fixed #1419 - 2.0: Continuous replicator does not restart in case Syn…

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
@@ -166,6 +166,10 @@ public class CBLWebSocket extends C4Socket {
                 else if (t instanceof java.net.SocketException) {
                     closed(handle, POSIXDomain, ECONNRESET);
                 }
+                // EOFException
+                else if (t instanceof java.io.EOFException) {
+                    closed(handle, POSIXDomain, ECONNRESET);
+                }
                 // Unknown
                 else {
                     closed(handle, WebSocketDomain, 0);


### PR DESCRIPTION
…c Gateway restarts.

- In case connection was closed by restarting Sync Gateway, java.io.EOFException is thrown. It should treat as connection reset error.