### PR TITLE
Fixed #1421 - 2.0: Replicator does not restart in case device became …

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
@@ -170,6 +170,10 @@ public class CBLWebSocket extends C4Socket {
                 else if (t instanceof java.io.EOFException) {
                     closed(handle, POSIXDomain, ECONNRESET);
                 }
+                // UnknownHostException - this is thrown if Airplane mode, offline
+                else if(t instanceof java.net.UnknownHostException){
+                    closed(handle, NetworkDomain, 1);
+                }
                 // Unknown
                 else {
                     closed(handle, WebSocketDomain, 0);


### PR DESCRIPTION
…ONLINE from OFFLINE

- Before device becomes ONLINE, the replicator could do retry already. In case of OFFLINE, the replicator could fail with UnknownHostException. Existing codes stops replicator with error code = 0, This makes replicator in non-transient.