### PR TITLE
Fixed #1418 - 2.0:testMissingHost() fails

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseReplicatorTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseReplicatorTest.java
@@ -87,6 +87,16 @@ public class BaseReplicatorTest extends BaseTest {
                         }
                         latch.countDown();
                     }
+                    else if(status.getActivityLevel() == Replicator.ActivityLevel.OFFLINE){
+                        if(code != 0){
+                            assertNotNull(error);
+                            assertEquals(code, error.getCode());
+                            assertEquals(domain, error.getDomainString());
+                            latch.countDown();
+                        }else{
+                            // TBD
+                        }
+                    }
                 } else {
                     if (status.getActivityLevel() == Replicator.ActivityLevel.STOPPED) {
                         if (code != 0) {

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorTest.java
@@ -158,11 +158,15 @@ public class ReplicatorTest extends BaseReplicatorTest {
     }
 
     // https://github.com/couchbase/couchbase-lite-core/issues/149
-    // @Test
+    @Test
     public void testMissingHost() throws InterruptedException {
         // should timeout after 10sec
         // builder.connectTimeout(10, TimeUnit.SECONDS)
         timeout = 20;
+
+        // NOTE: Following URL causes UnknownHostException which is transient error,
+        //       and replicator status becomes OFFLINE
+
         String uri = String.format(Locale.ENGLISH, "blip://foo.couchbase.com/db");
         ReplicatorConfiguration config = makeConfig(false, true, true, uri);
         run(config, kC4NetErrUnknownHost, "Network");

--- a/shared/src/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/replicator/CBLWebSocket.java
@@ -48,6 +48,7 @@ import static com.couchbase.litecore.C4Constants.C4ErrorDomain.NetworkDomain;
 import static com.couchbase.litecore.C4Constants.C4ErrorDomain.POSIXDomain;
 import static com.couchbase.litecore.C4Constants.C4ErrorDomain.WebSocketDomain;
 import static com.couchbase.litecore.C4Constants.NetworkError.kC4NetErrTLSCertUntrusted;
+import static com.couchbase.litecore.C4Constants.NetworkError.kC4NetErrUnknownHost;
 
 public class CBLWebSocket extends C4Socket {
     //-------------------------------------------------------------------------
@@ -172,7 +173,7 @@ public class CBLWebSocket extends C4Socket {
                 }
                 // UnknownHostException - this is thrown if Airplane mode, offline
                 else if(t instanceof java.net.UnknownHostException){
-                    closed(handle, NetworkDomain, 1);
+                    closed(handle, NetworkDomain, kC4NetErrUnknownHost);
                 }
                 // Unknown
                 else {


### PR DESCRIPTION
- In case of UnknownHostException, set error code kC4NetErrUnknonHost instead of DNS error.
- As it is transient error, fixed unit test for it.