### PR TITLE
 Fixed #1474 - 2.0: Implement Blob.equals()/hashCode() 

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BlobTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BlobTest.java
@@ -46,9 +46,8 @@ public class BlobTest extends BaseTest {
         assertFalse(blob2a.equals(blob1a));
         assertFalse(blob2a.equals(blob1b));
 
-        // TODO - confirm spec
-        assertFalse(blob1a.equals(data1c));
-        assertFalse(data1c.equals(blob1a));
+        assertTrue(blob1a.equals(data1c));
+        assertTrue(data1c.equals(blob1a));
     }
     @Test
     public void testHashCode() throws CouchbaseLiteException {
@@ -86,8 +85,7 @@ public class BlobTest extends BaseTest {
         assertFalse(blob2a.hashCode() == blob1a.hashCode());
         assertFalse(blob2a.hashCode() == blob1b.hashCode());
 
-        // TODO - confirm spec
-        assertFalse(blob1a.hashCode() == data1c.hashCode());
-        assertFalse(data1c.hashCode() == blob1a.hashCode());
+        assertTrue(blob1a.hashCode() == data1c.hashCode());
+        assertTrue(data1c.hashCode() == blob1a.hashCode());
     }
 }

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BlobTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BlobTest.java
@@ -1,0 +1,93 @@
+package com.couchbase.lite;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BlobTest extends BaseTest {
+    final static String kBlobTestBlob1 = "i'm blob";
+    final static String kBlobTestBlob2 = "i'm blob2";
+
+    @Test
+    public void testEquals() throws CouchbaseLiteException {
+
+        byte[] content1a = kBlobTestBlob1.getBytes();
+        byte[] content1b = kBlobTestBlob1.getBytes();
+        byte[] content2a = kBlobTestBlob2.getBytes();
+
+        // store blob
+        Blob data1a = new Blob("text/plain", content1a);
+        Blob data1b = new Blob("text/plain", content1b);
+        Blob data1c = new Blob("text/plain", content1a); // not store in db
+        Blob data2a = new Blob("text/plain", content2a);
+
+        assertTrue(data1a.equals(data1b));
+        assertTrue(data1b.equals(data1a));
+        assertFalse(data1a.equals(data2a));
+        assertFalse(data1b.equals(data2a));
+        assertFalse(data2a.equals(data1a));
+        assertFalse(data2a.equals(data1b));
+
+        MutableDocument mDoc = new MutableDocument();
+        mDoc.setBlob("blob1a", data1a);
+        mDoc.setBlob("blob1b", data1b);
+        mDoc.setBlob("blob2a", data2a);
+        Document doc = save(mDoc);
+
+        Blob blob1a = doc.getBlob("blob1a");
+        Blob blob1b = doc.getBlob("blob1b");
+        Blob blob2a = doc.getBlob("blob2a");
+
+        assertTrue(blob1a.equals(blob1b));
+        assertTrue(blob1b.equals(blob1a));
+        assertFalse(blob1a.equals(blob2a));
+        assertFalse(blob1b.equals(blob2a));
+        assertFalse(blob2a.equals(blob1a));
+        assertFalse(blob2a.equals(blob1b));
+
+        // TODO - confirm spec
+        assertFalse(blob1a.equals(data1c));
+        assertFalse(data1c.equals(blob1a));
+    }
+    @Test
+    public void testHashCode() throws CouchbaseLiteException {
+        byte[] content1a = kBlobTestBlob1.getBytes();
+        byte[] content1b = kBlobTestBlob1.getBytes();
+        byte[] content2a = kBlobTestBlob2.getBytes();
+
+        // store blob
+        Blob data1a = new Blob("text/plain", content1a);
+        Blob data1b = new Blob("text/plain", content1b);
+        Blob data1c = new Blob("text/plain", content1a); // not store in db
+        Blob data2a = new Blob("text/plain", content2a);
+
+        assertTrue(data1a.hashCode() == data1b.hashCode());
+        assertTrue(data1b.hashCode() == data1a.hashCode());
+        assertFalse(data1a.hashCode() == data2a.hashCode());
+        assertFalse(data1b.hashCode() == data2a.hashCode());
+        assertFalse(data2a.hashCode() == data1a.hashCode());
+        assertFalse(data2a.hashCode() == data1b.hashCode());
+
+        MutableDocument mDoc = new MutableDocument();
+        mDoc.setBlob("blob1a", data1a);
+        mDoc.setBlob("blob1b", data1b);
+        mDoc.setBlob("blob2a", data2a);
+        Document doc = save(mDoc);
+
+        Blob blob1a = doc.getBlob("blob1a");
+        Blob blob1b = doc.getBlob("blob1b");
+        Blob blob2a = doc.getBlob("blob2a");
+
+        assertTrue(blob1a.hashCode() == blob1b.hashCode());
+        assertTrue(blob1b.hashCode() == blob1a.hashCode());
+        assertFalse(blob1a.hashCode() == blob2a.hashCode());
+        assertFalse(blob1b.hashCode() == blob2a.hashCode());
+        assertFalse(blob2a.hashCode() == blob1a.hashCode());
+        assertFalse(blob2a.hashCode() == blob1b.hashCode());
+
+        // TODO - confirm spec
+        assertFalse(blob1a.hashCode() == data1c.hashCode());
+        assertFalse(data1c.hashCode() == blob1a.hashCode());
+    }
+}

--- a/shared/src/main/java/com/couchbase/lite/Blob.java
+++ b/shared/src/main/java/com/couchbase/lite/Blob.java
@@ -289,6 +289,10 @@ public final class Blob implements FLEncodable {
         }
     }
 
+    //---------------------------------------------
+    // Override
+    //---------------------------------------------
+
     /**
      * Returns a string representation of the object.
      *
@@ -298,6 +302,40 @@ public final class Blob implements FLEncodable {
     public String toString() {
         return String.format(Locale.ENGLISH, "Blob[%s; %d KB]",
                 contentType, (length() + 512) / 1024);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Blob)) return false;
+
+        Blob m = (Blob) o;
+
+        // saved blob
+        if (database != null && digest != null && m.database != null && m.digest != null)
+            return database.equalsWithPath(m.database) && digest.equals(m.digest);
+
+        // unsaved blob
+        if (database == null && digest == null && m.database == null && m.digest == null)
+            return Arrays.equals(getContent(), m.getContent());
+
+        // unsaved vs saved
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        int h = 0;
+        // saved blob
+        if (database != null && digest != null) {
+            h = h * 31 + database.hashCode();
+            h = h * 31 + digest.hashCode();
+        }
+        // unsaved blob
+        else {
+            h = h * 31 + Arrays.hashCode(getContent());
+        }
+        return h;
     }
 
     //---------------------------------------------

--- a/shared/src/main/java/com/couchbase/lite/Blob.java
+++ b/shared/src/main/java/com/couchbase/lite/Blob.java
@@ -310,32 +310,15 @@ public final class Blob implements FLEncodable {
         if (!(o instanceof Blob)) return false;
 
         Blob m = (Blob) o;
-
-        // saved blob
-        if (database != null && digest != null && m.database != null && m.digest != null)
-            return database.equalsWithPath(m.database) && digest.equals(m.digest);
-
-        // unsaved blob
-        if (database == null && digest == null && m.database == null && m.digest == null)
+        if (digest != null && m.digest != null)
+            return digest.equals(m.digest);
+        else
             return Arrays.equals(getContent(), m.getContent());
-
-        // unsaved vs saved
-        return false;
     }
 
     @Override
     public int hashCode() {
-        int h = 0;
-        // saved blob
-        if (database != null && digest != null) {
-            h = h * 31 + database.hashCode();
-            h = h * 31 + digest.hashCode();
-        }
-        // unsaved blob
-        else {
-            h = h * 31 + Arrays.hashCode(getContent());
-        }
-        return h;
+        return Arrays.hashCode(getContent());
     }
 
     //---------------------------------------------

--- a/shared/src/main/java/com/couchbase/lite/Database.java
+++ b/shared/src/main/java/com/couchbase/lite/Database.java
@@ -667,6 +667,18 @@ public final class Database implements C4Constants {
     //---------------------------------------------
     // Package level access
     //---------------------------------------------
+    boolean equalsWithPath(Database other) {
+        if (other == null) return false;
+        File path = getPath();
+        File otherPath = other.getPath();
+        if (path == null && otherPath == null)
+            return true;
+        else if ((path == null && otherPath != null) || (path != null && otherPath == null))
+            return false;
+        else
+            return path.equals(otherPath);
+    }
+
     C4BlobStore getBlobStore() throws CouchbaseLiteRuntimeException {
         mustBeOpen();
         try {

--- a/shared/src/main/java/com/couchbase/lite/Document.java
+++ b/shared/src/main/java/com/couchbase/lite/Document.java
@@ -336,7 +336,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
     @Override
     public int hashCode() {
         // NOTE _id and _dict never null
-        int result = _database != null ? _database.hashCode() : 0;
+        int result = _database != null && _database.getPath() != null ? _database.getPath().hashCode() : 0;
         result = 31 * result + _id.hashCode();
         result = 31 * result + _dict.hashCode();
         return result;

--- a/shared/src/main/java/com/couchbase/lite/Document.java
+++ b/shared/src/main/java/com/couchbase/lite/Document.java
@@ -317,7 +317,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
         Document doc = (Document) o;
 
         // Step 1: Check Database
-        if (_database != null ? !_database.equals(doc._database) : doc._database != null)
+        if (_database != null ? !_database.equalsWithPath(doc._database) : doc._database != null)
             return false;
 
         // Step 2: Check document ID


### PR DESCRIPTION
- Implement Blob.equals()/hashCode()
- Fixed Document.equals() and hashCode() with Database.