### PR TITLE
Fixed #1529 - Editing tasks concurrently fails with LiteCoreException…

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/Document.java
+++ b/shared/src/main/java/com/couchbase/lite/Document.java
@@ -475,7 +475,7 @@ public class Document implements DictionaryInterface, Iterable<String> {
             _c4doc.selectNextLeafRevision(false, true);
             setC4Document(_c4doc); // self.c4Doc = _c4Doc; // This will update to the selected revision
         } catch (LiteCoreException e) {
-            Log.e(TAG, "Failed to selectNextLeaf: doc -> %s", e, _c4doc);
+            Log.i(TAG, "Failed to selectNextLeaf: doc -> %s", e, _c4doc);
             return false;
         }
         return true;


### PR DESCRIPTION
… Failed to selectNextLeaf

- This stacktrace should not be printed with Error log level. This could be happens.