### PR TITLE
Fixed #1534 - 2.0: LiveQuery.destroy() cause problem if Database is a…

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseReplicatorTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseReplicatorTest.java
@@ -129,9 +129,14 @@ public class BaseReplicatorTest extends BaseTest {
         conflictResolver = new ConflictTest.MergeThenTheirsWins();
         super.setUp();
 
-        timeout = 10; // seconds
+        timeout = 15; // seconds
         otherDB = open("otherdb");
         assertNotNull(otherDB);
+
+        try {
+            Thread.sleep(1000);
+        } catch (Exception e) {
+        }
     }
 
     @After
@@ -140,7 +145,13 @@ public class BaseReplicatorTest extends BaseTest {
             otherDB.close();
             otherDB = null;
         }
+        deleteDatabase("otherdb");
 
         super.tearDown();
+
+        try {
+            Thread.sleep(1000);
+        } catch (Exception e) {
+        }
     }
 }

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseTest.java
@@ -97,7 +97,7 @@ public class BaseTest implements C4Constants {
                 } catch (CouchbaseLiteException ex) {
                     if (ex.getCode() == kC4ErrorBusy) {
                         try {
-                            Thread.sleep(300);
+                            Thread.sleep(500);
                         } catch (Exception e) {
                         }
                     } else {

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorTest.java
@@ -369,12 +369,6 @@ public class ReplicatorTest extends BaseReplicatorTest {
         ReplicatorConfiguration.Builder builder = makeConfig(true, true, false);
         run(builder.build(), 0, null);
 
-        // give extra time
-        try {
-            Thread.sleep(1000);
-        } catch (Exception e) {
-        }
-
         assertEquals(1, db.getCount());
         Document doc1a = db.getDocument("doc1");
         Blob blob1a = doc1a.getBlob("image.jpg");

--- a/shared/src/main/java/com/couchbase/lite/Database.java
+++ b/shared/src/main/java/com/couchbase/lite/Database.java
@@ -398,7 +398,6 @@ public final class Database {
             throw new IllegalArgumentException("a token parameter is null");
 
         synchronized (lock) {
-            mustBeOpen();
             if (token instanceof DocumentChangeListenerToken)
                 removeDocumentChangeListener((DocumentChangeListenerToken) token);
             else
@@ -723,6 +722,10 @@ public final class Database {
         if (c4db == null)
             throw new CouchbaseLiteRuntimeException("A database is not open",
                     C4ErrorDomain.LiteCoreDomain, LiteCoreError.kC4ErrorNotOpen);
+    }
+
+    boolean isOpen() {
+        return c4db != null;
     }
 
     /**

--- a/shared/src/main/java/com/couchbase/lite/LiveQuery.java
+++ b/shared/src/main/java/com/couchbase/lite/LiveQuery.java
@@ -113,7 +113,7 @@ final class LiveQuery implements DatabaseChangeListener {
         observing = false;
         willUpdate = false; // cancels the delayed update started by -databaseChanged
         query.getDatabase().removeChangeListener(dbListenerToken);
-        if(removeFromList)
+        if (removeFromList)
             query.getDatabase().getActiveLiveQueries().remove(this);
         releaseResultSet();
     }


### PR DESCRIPTION
…lready closed.

- Fixed: LiveQuery instance could be garbage collected after Database is closed. `LiveQuery.destroy()` could throw the Exception.
- Fixed: unit test issue