### PR TITLE
Fixed #1537 : Update URLEndpoint API

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseReplicatorTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseReplicatorTest.java
@@ -27,39 +27,25 @@ public class BaseReplicatorTest extends BaseTest {
     Replicator repl;
     long timeout;  // seconds
 
-    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull,
-                                                         boolean continuous) {
+    protected URLEndpoint getRemoteEndpoint(String dbName, boolean secure) throws URISyntaxException {
+        String uri = (secure ? "wss://" : "ws://") + config.remoteHost() + ":" + config.remotePort() + "/" + dbName;
+        return new URLEndpoint(new URI(uri));
+    }
+
+    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull, boolean continuous) {
         return makeConfig(push, pull, continuous, this.otherDB);
     }
 
-    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull,
-                                                         boolean continuous, Database targetDatabase) {
-        DatabaseEndpoint endpoint = new DatabaseEndpoint(targetDatabase);
-        ReplicatorConfiguration.Builder builder = new ReplicatorConfiguration.Builder(this.db, endpoint);
-        builder.setReplicatorType(push && pull ? PUSH_AND_PULL : (push ? PUSH : PULL));
-        builder.setContinuous(continuous);
-        return builder;
+    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull, boolean continuous, Database targetDatabase) {
+        return makeConfig(push, pull, continuous, this.db, new DatabaseEndpoint(targetDatabase));
     }
 
-    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull,
-                                                         boolean continuous, String targetURI) throws URISyntaxException {
-        return makeConfig(push, pull, continuous, URI.create(targetURI));
-    }
-
-    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull,
-                                                         boolean continuous, URI target) throws URISyntaxException {
+    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull, boolean continuous, Endpoint target) {
         return makeConfig(push, pull, continuous, this.db, target);
     }
 
-    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull,
-                                                         boolean continuous, Database db, String targetURI) throws URISyntaxException {
-        return makeConfig(push, pull, continuous, db, URI.create(targetURI));
-    }
-
-    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull,
-                                                         boolean continuous, Database db, URI targetURI) throws URISyntaxException {
-        URLEndpoint endpoint = new URLEndpoint(targetURI.getHost(), targetURI.getPort(), targetURI.getPath(), false);
-        ReplicatorConfiguration.Builder builder = new ReplicatorConfiguration.Builder(db, endpoint);
+    protected ReplicatorConfiguration.Builder makeConfig(boolean push, boolean pull, boolean continuous, Database db, Endpoint target) {
+        ReplicatorConfiguration.Builder builder = new ReplicatorConfiguration.Builder(db, target);
         builder.setReplicatorType(push && pull ? PUSH_AND_PULL : (push ? PUSH : PULL));
         builder.setContinuous(continuous);
         return builder;

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewayDBTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewayDBTest.java
@@ -70,9 +70,8 @@ public class ReplicatorWithSyncGatewayDBTest extends BaseReplicatorTest {
         if (!config.replicatorTestsEnabled())
             return;
 
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/%s",
-                this.config.remoteHost(), this.config.remotePort(), DB_NAME);
-        ReplicatorConfiguration.Builder builder = makeConfig(true, false, false, uri);
+        Endpoint target = getRemoteEndpoint(DB_NAME, false);
+        ReplicatorConfiguration.Builder builder = makeConfig(true, false, false, target);
         run(builder.build(), 0, null);
     }
 
@@ -85,15 +84,14 @@ public class ReplicatorWithSyncGatewayDBTest extends BaseReplicatorTest {
         loadJSONResource("names_100.json");
 
         // target SG URI
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/%s",
-                this.config.remoteHost(), this.config.remotePort(), DB_NAME);
+        Endpoint target = getRemoteEndpoint(DB_NAME, false);
 
         // Push replicate from db to SG
-        ReplicatorConfiguration.Builder builder = makeConfig(true, false, false, uri);
+        ReplicatorConfiguration.Builder builder = makeConfig(true, false, false, target);
         run(builder.build(), 0, null);
 
         // Pull replicate from SG to otherDB.
-        builder = makeConfig(false, true, false, this.otherDB, uri);
+        builder = makeConfig(false, true, false, this.otherDB, target);
         run(builder.build(), 0, null);
         assertEquals(100, this.otherDB.getCount());
     }
@@ -116,8 +114,8 @@ public class ReplicatorWithSyncGatewayDBTest extends BaseReplicatorTest {
         loadJSONResource("names_100.json");
 
         timeout = 180; // 3min
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/%s", this.config.remoteHost(), this.config.remotePort(), DB_NAME);
-        ReplicatorConfiguration.Builder builder = makeConfig(true, false, true, uri);
+        Endpoint target = getRemoteEndpoint(DB_NAME, false);
+        ReplicatorConfiguration.Builder builder = makeConfig(true, false, true, target);
         run(builder.build(), 0, null);
     }
 
@@ -153,12 +151,11 @@ public class ReplicatorWithSyncGatewayDBTest extends BaseReplicatorTest {
             }
         });
 
-        String strUri = String.format(Locale.ENGLISH, "blip://%s:%d/%s", this.config.remoteHost(), this.config.remotePort(), DB_NAME);
-        URI uri = new URI(strUri);
-        ReplicatorConfiguration.Builder builder = makeConfig(true, false, false, uri);
+        Endpoint target = getRemoteEndpoint(DB_NAME, false);
+        ReplicatorConfiguration.Builder builder = makeConfig(true, false, false, target);
         run(builder.build(), 0, null);
 
-        builder = makeConfig(false, true, false, otherDB, uri);
+        builder = makeConfig(false, true, false, otherDB, target);
         builder.setChannels(Arrays.asList("my_channel"));
         run(builder.build(), 0, null);
         assertEquals(10, otherDB.getCount());
@@ -192,15 +189,14 @@ public class ReplicatorWithSyncGatewayDBTest extends BaseReplicatorTest {
         }
 
         // target SG URI
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/%s",
-                this.config.remoteHost(), this.config.remotePort(), DB_NAME);
+        Endpoint target = getRemoteEndpoint(DB_NAME, false);
 
         // Push replicate from db to SG
-        ReplicatorConfiguration.Builder builder = makeConfig(true, false, false, uri);
+        ReplicatorConfiguration.Builder builder = makeConfig(true, false, false, target);
         run(builder.build(), 0, null);
 
         // Pull replicate from SG to otherDB.
-        builder = makeConfig(false, true, false, this.otherDB, uri);
+        builder = makeConfig(false, true, false, this.otherDB, target);
         run(builder.build(), 0, null);
         assertEquals(1, this.otherDB.getCount());
         Document doc = otherDB.getDocument("doc1");

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewaySSLTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewaySSLTest.java
@@ -23,8 +23,8 @@ public class ReplicatorWithSyncGatewaySSLTest extends BaseReplicatorTest {
     public void testSelfSignedSSLFailure() throws InterruptedException, URISyntaxException {
         if (!config.replicatorTestsEnabled()) return;
 
-        String uri = String.format(Locale.ENGLISH, "blips://%s:4995/beer", this.config.remoteHost());
-        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, uri);
+        Endpoint target = getRemoteEndpoint("beer", true);
+        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, target);
         run(builder.build(), kC4NetErrTLSCertUntrusted, "Network");
     }
 
@@ -42,9 +42,8 @@ public class ReplicatorWithSyncGatewaySSLTest extends BaseReplicatorTest {
         byte[] cert = IOUtils.toByteArray(is);
         is.close();
 
-        String uri = String.format(Locale.ENGLISH, "blips://%s:%d/beer",
-                this.config.remoteHost(), this.config.remotePort());
-        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, uri);
+        Endpoint target = getRemoteEndpoint("beer", true);
+        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, target);
         builder.setPinnedServerCertificate(cert);
         run(builder.build(), 0, null);
     }

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewayTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewayTest.java
@@ -2,12 +2,10 @@ package com.couchbase.lite;
 
 import com.couchbase.lite.internal.support.Log;
 
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.net.URISyntaxException;
 import java.util.Locale;
 
 import okhttp3.MediaType;
@@ -49,71 +47,55 @@ public class ReplicatorWithSyncGatewayTest extends BaseReplicatorTest {
     public void testEmptyPullFromRemoteDB() throws Exception {
         if (!config.replicatorTestsEnabled()) return;
 
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/scratch",
-                this.config.remoteHost(), this.config.remotePort());
-        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, uri);
+        Endpoint target = getRemoteEndpoint("scratch", false);
+        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, target);
         run(builder.build(), 0, null);
     }
 
     @Test
-    public void testAuthenticationFailure() throws InterruptedException, URISyntaxException {
+    public void testAuthenticationFailure() throws Exception {
         if (!config.replicatorTestsEnabled()) return;
 
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit",
-                this.config.remoteHost(), this.config.remotePort());
-        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, uri);
+        Endpoint target = getRemoteEndpoint("seekrit", false);
+        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, target);
         run(builder.build(), 401, "WebSocket");
     }
 
     @Test
-    public void testAuthenticatedPullWithIncorrectPassword() throws InterruptedException, URISyntaxException {
+    public void testAuthenticatedPullWithIncorrectPassword() throws Exception {
         if (!config.replicatorTestsEnabled()) return;
 
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit",
-                this.config.remoteHost(), this.config.remotePort());
-        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, uri);
+        Endpoint target = getRemoteEndpoint("seekrit", false);
+        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, target);
         builder.setAuthenticator(new BasicAuthenticator("pupshaw", "frank!"));
-        // Retry 3 times then fails with 401
-        run(builder.build(), 401, "WebSocket");
+        run(builder.build(), 401, "WebSocket"); // Retry 3 times then fails with 401
     }
 
     @Test
-    public void testAuthenticatedPullHardcoded() throws InterruptedException, URISyntaxException {
+    public void testAuthenticatedPull() throws Exception {
         if (!config.replicatorTestsEnabled()) return;
 
-        String uri = String.format(Locale.ENGLISH, "blip://pupshaw:frank@%s:%d/seekrit",
-                this.config.remoteHost(), this.config.remotePort());
-        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, uri);
-        run(builder.build(), 0, null);
-    }
-
-    @Test
-    public void testAuthenticatedPull() throws InterruptedException, URISyntaxException {
-        if (!config.replicatorTestsEnabled()) return;
-
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit",
-                this.config.remoteHost(), this.config.remotePort());
-        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, uri);
+        Endpoint target = getRemoteEndpoint("seekrit", false);
+        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, target);
         builder.setAuthenticator(new BasicAuthenticator("pupshaw", "frank"));
         run(builder.build(), 0, null);
     }
 
     @Test
-    public void testSessionAuthenticatorPull() throws InterruptedException, IOException, JSONException, URISyntaxException {
+    public void testSessionAuthenticatorPull() throws Exception {
         if (!config.replicatorTestsEnabled()) return;
 
         // Obtain Sync-Gateway Session ID
         SessionAuthenticator auth = getSessionAuthenticatorFromSG();
         Log.e(TAG, "auth -> " + auth);
 
-        String uri = String.format(Locale.ENGLISH, "blip://%s:%d/seekrit",
-                this.config.remoteHost(), this.config.remotePort());
-        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, uri);
+        Endpoint target = getRemoteEndpoint("seekrit", false);
+        ReplicatorConfiguration.Builder builder = makeConfig(false, true, false, target);
         builder.setAuthenticator(auth);
         run(builder.build(), 0, null);
     }
 
-    SessionAuthenticator getSessionAuthenticatorFromSG() throws IOException, JSONException {
+    SessionAuthenticator getSessionAuthenticatorFromSG() throws Exception {
         // Obtain Sync-Gateway Session ID
         final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
         OkHttpClient client = new OkHttpClient();

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/api/ReplicationAPITest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/api/ReplicationAPITest.java
@@ -48,8 +48,8 @@ public class ReplicationAPITest extends BaseReplicatorTest {
         if (!config.replicatorTestsEnabled()) return;
 
         // --- code example ---
-        URI uri = new URI("blip://localhost:4984/db");
-        Endpoint endpoint = new URLEndpoint(uri.getHost(), uri.getPort(), uri.getPath(), false);
+        URI uri = new URI("ws://localhost:4984/db");
+        Endpoint endpoint = new URLEndpoint(uri);
         ReplicatorConfiguration.Builder builder = new ReplicatorConfiguration.Builder(database, endpoint);
         builder.setReplicatorType(ReplicatorConfiguration.ReplicatorType.PULL);
         Replicator replication = new Replicator(builder.build());
@@ -72,8 +72,8 @@ public class ReplicationAPITest extends BaseReplicatorTest {
     public void testReplicationStatus() throws URISyntaxException {
         if (!config.replicatorTestsEnabled()) return;
 
-        URI uri = new URI("blip://localhost:4984/db");
-        Endpoint endpoint = new URLEndpoint(uri.getHost(), uri.getPort(), uri.getPath(), false);
+        URI uri = new URI("ws://localhost:4984/db");
+        Endpoint endpoint = new URLEndpoint(uri);
         ReplicatorConfiguration.Builder builder = new ReplicatorConfiguration.Builder(database, endpoint);
         builder.setReplicatorType(ReplicatorConfiguration.ReplicatorType.PULL);
         Replicator replication = new Replicator(builder.build());
@@ -93,8 +93,8 @@ public class ReplicationAPITest extends BaseReplicatorTest {
     public void testHandlingNetworkErrors() throws URISyntaxException {
         if (!config.replicatorTestsEnabled()) return;
 
-        URI uri = new URI("blip://localhost:4984/db");
-        Endpoint endpoint = new URLEndpoint(uri.getHost(), uri.getPort(), uri.getPath(), false);
+        URI uri = new URI("ws://localhost:4984/db");
+        Endpoint endpoint = new URLEndpoint(uri);
         ReplicatorConfiguration.Builder builder = new ReplicatorConfiguration.Builder(database, endpoint);
         builder.setReplicatorType(ReplicatorConfiguration.ReplicatorType.PULL);
         Replicator replication = new Replicator(builder.build());

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/internal/utils/URIUtilsTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/internal/utils/URIUtilsTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.assertEquals;
 public class URIUtilsTest {
     @Test
     public void testGetPort() throws URISyntaxException {
-        URI uri = new URI("blip://foo.couchbase.com/db");
+        URI uri = new URI("ws://foo.couchbase.com/db");
         assertEquals(-1, uri.getPort());
     }
 }

--- a/shared/src/main/java/com/couchbase/lite/ReplicatorConfiguration.java
+++ b/shared/src/main/java/com/couchbase/lite/ReplicatorConfiguration.java
@@ -395,7 +395,7 @@ public final class ReplicatorConfiguration {
     URI getTargetURI() {
         if (target instanceof URLEndpoint) {
             URLEndpoint urlEndpoint = (URLEndpoint) target;
-            return urlEndpoint.getURI();
+            return urlEndpoint.getURL();
         } else
             return null;
     }

--- a/shared/src/main/java/com/couchbase/lite/URLEndpoint.java
+++ b/shared/src/main/java/com/couchbase/lite/URLEndpoint.java
@@ -3,72 +3,50 @@ package com.couchbase.lite;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import static com.couchbase.litecore.C4Replicator.kC4Replicator2Scheme;
-import static com.couchbase.litecore.C4Replicator.kC4Replicator2TLSScheme;
-
 /**
  * URL based replication target endpoint
  */
 public final class URLEndpoint implements Endpoint {
     //---------------------------------------------
+    // Constant variables
+    //---------------------------------------------
+    private static final String kURLEndpointScheme = "ws";
+    private static final String kURLEndpointTLSScheme = "wss";
+
+    //---------------------------------------------
     // Member variables
     //---------------------------------------------
-    private final String host;
-    private final int port;
-    private final String path;
-    private final boolean secure;
-    private final URI uri;
+    private final URI url;
 
     //---------------------------------------------
     // Constructors
     //---------------------------------------------
 
     /**
-     * Constructor with the host and the secure flag.
+     * Constructor with the url. The supported URL schemes
+     * are ws and wss for transferring data over a secure channel.
      *
-     * @param host   Host name
-     * @param secure The secure flag indicating whether the replication data will be sent over secure channels
-     * @throws URISyntaxException
+     * @param url   The url.
      */
-    public URLEndpoint(String host, boolean secure) throws URISyntaxException {
-        this(host, null, secure);
-    }
+    public URLEndpoint(URI url) {
+        if (url == null) {
+            throw new IllegalArgumentException("The url parameter cannot be null.");
+        }
 
-    /**
-     * Constructor with the host, the path and the secure flag.
-     *
-     * @param host   Host name
-     * @param path   Path
-     * @param secure The secure flag indicating whether the replication data will be sent over secure channels
-     * @throws URISyntaxException
-     */
-    public URLEndpoint(String host, String path, boolean secure) throws URISyntaxException {
-        this(host, -1, path, secure);
-    }
+        String scheme = url.getScheme();
+        if (!(kURLEndpointScheme.equals(scheme) || kURLEndpointTLSScheme.equals(scheme))) {
+            throw new IllegalArgumentException(
+                    "The url parameter has an unsupported URL scheme (" + scheme + ") " +
+                    "The supported URL schemes are " + kURLEndpointScheme + " and " + kURLEndpointTLSScheme + ".");
+        }
 
-    /**
-     * Constructor with the host, the port, the path and the secure flag.
-     *
-     * @param host   Host name
-     * @param port   Port number
-     * @param path   Path
-     * @param secure The secure flag indicating whether the replication data will be sent over secure channels
-     * @throws URISyntaxException
-     */
-    public URLEndpoint(String host, int port, String path, boolean secure) throws URISyntaxException {
-        this.host = host;
-        this.port = port;
-        this.path = path;
-        this.secure = secure;
-
-        String scheme = secure ? kC4Replicator2TLSScheme : kC4Replicator2Scheme;
-        this.uri = new URI(scheme, null, host, port, path, null, null);
+        this.url = url;
     }
 
     @Override
     public String toString() {
         return "URLEndpoint{" +
-                "uri=" + uri +
+                "url=" + url +
                 '}';
     }
 
@@ -77,34 +55,9 @@ public final class URLEndpoint implements Endpoint {
     //---------------------------------------------
 
     /**
-     * Returns the host component of this URLEndpoint.
+     * Returns the url.
      */
-    public String getHost() {
-        return host;
-    }
-
-    /**
-     * Returns the port number of this URLEndpoint.
-     */
-    public int getPort() {
-        return port;
-    }
-
-    /**
-     * Returns the decoded path component of this URLEndpoint.
-     */
-    public String getPath() {
-        return path;
-    }
-
-    /**
-     * Return the boolean value indicates whether the replication data will be sent over secure channels.
-     */
-    public boolean isSecure() {
-        return secure;
-    }
-
-    URI getURI() {
-        return uri;
+    public URI getURL() {
+        return url;
     }
 }


### PR DESCRIPTION
The new API has only one constructor which takes a URI object. The supported schemes are ws and wss.

#1537