### PR TITLE
Fixed #1597 and #1522 : Port error handling logic from iOS CBLWebSocket (Rework)

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewayDBTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewayDBTest.java
@@ -197,7 +197,8 @@ public class ReplicatorWithSyncGatewayDBTest extends BaseReplicatorTest {
         timeout = 180; // 3min
         Endpoint target = getRemoteEndpoint(DB_NAME, false);
         ReplicatorConfiguration config = makeConfig(true, false, true, target);
-        run(config, 0, null);
+        Replicator repl = run(config, 0, null);
+        stopContinuousReplicator(repl);
     }
 
     @Test

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewayTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorWithSyncGatewayTest.java
@@ -97,7 +97,7 @@ public class ReplicatorWithSyncGatewayTest extends BaseReplicatorTest {
 
         Endpoint target = getRemoteEndpoint("seekrit", false);
         ReplicatorConfiguration config = makeConfig(false, true, false, target);
-        run(config, 401, "WebSocket");
+        run(config, CBLErrorHTTPAuthRequired, CBLErrorDomain);
     }
 
     @Test
@@ -107,12 +107,13 @@ public class ReplicatorWithSyncGatewayTest extends BaseReplicatorTest {
         Endpoint target = getRemoteEndpoint("seekrit", false);
         ReplicatorConfiguration config = makeConfig(false, true, false, target);
         config.setAuthenticator(new BasicAuthenticator("pupshaw", "frank!"));
-        run(config, 401, "WebSocket"); // Retry 3 times then fails with 401
+        run(config, CBLErrorHTTPAuthRequired, CBLErrorDomain); // Retry 3 times then fails with 401
     }
 
     @Test
     public void testAuthenticatedPull() throws Exception {
         if (!config.replicatorTestsEnabled()) return;
+
 
         Endpoint target = getRemoteEndpoint("seekrit", false);
         ReplicatorConfiguration config = makeConfig(false, true, false, target);


### PR DESCRIPTION
- It turns out OKHTTP has already handled protocol based error check, including validating Sec-WebSocket-Accept, checking connection header and checking upgrade here. We don’t need to that by outselves anymore. So reverted the changes back.

- Ported error handling logic from iOS and implemented that in onFailure() callback.

- Fixed Replicator unit test issues.

#1522 #1597