### PR TITLE
Fixes #1611 Attachment images added in ios do not show up in android

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ dependencies {
 
 - [Developer Guide](https://developer.couchbase.com/documentation/mobile/2.0/couchbase-lite/java.html)
 
+## How to build from source
+
+1. `git clone --recursive https://github.com/couchbase/couchbase-lite-android.git` to clone this repo and it's submodules
+1. In Android Studio, open the `android` subdirectory
+1. [Install CMake](https://stackoverflow.com/questions/41218241/unable-to-find-cmake-in-android-studio)
+
+At this point it should build without errors.
+
 ## Sample Apps
 
 - [Todo](https://github.com/couchbaselabs/mobile-training-todo/tree/feature/2.0)
@@ -44,5 +52,5 @@ dependencies {
 
 ## License
 
-Like all Couchbase source code, this is released under the Apache 2 [license](LICENSE).
+Apache 2 [license](LICENSE).
 

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BlobTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BlobTest.java
@@ -159,4 +159,32 @@ public class BlobTest extends BaseTest {
         byte[] content = blob.getContent();
         assertTrue(Arrays.equals(content, bytes));
     }
+
+    // https://github.com/couchbase/couchbase-lite-android/issues/1611
+    @Test
+    public void testGetNonCachedContent6MBFile() throws IOException, CouchbaseLiteException {
+        byte[] bytes;
+
+        InputStream is = getAsset("iTunesMusicLibrary.json");
+        try {
+            bytes = IOUtils.toByteArray(is);
+        } finally {
+            is.close();
+        }
+
+        Blob blob = new Blob("application/json", bytes);
+        MutableDocument mDoc = new MutableDocument("doc1");
+        mDoc.setBlob("blob", blob);
+        Document doc = save(mDoc);
+
+        // Reload the doc from the database to make sure to "bust the cache" for the blob
+        // cached in the doc object
+        Document reloadedDoc = db.getDocument(doc.getId());
+        Blob savedBlob = reloadedDoc.getBlob("blob");
+        byte[] content = savedBlob.getContent();
+        assertTrue(Arrays.equals(content, bytes));
+
+    }
+
+
 }


### PR DESCRIPTION
Fixes #1611 

- [x] Add unit test to repro -- unloads and reloads the doc to force the blob out of the doc's cache
- [x] Fix underlying issue by returning the content regardless of size, but only caching it if it's less than or equal to `MAX_CACHED_CONTENT_LENGTH`