### PR TITLE
Fixed #1625 - 2.0: FLSharedKeys thread safety

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/Result.java
+++ b/shared/src/main/java/com/couchbase/lite/Result.java
@@ -476,7 +476,9 @@ public final class Result implements ArrayInterface, DictionaryInterface, Iterab
         FLValue value = values.get(index);
         if (value == null) return null;
         MRoot root = new MRoot(context, value, false);
-        return root.asNative();
+        synchronized (rs.getQuery().getDatabase().getLock()) {
+            return root.asNative();
+        }
     }
 
     List<FLValue> extractColumns(FLArrayIterator columns) {


### PR DESCRIPTION
- Result accesses data with using FLSharedKeys. So this method should be locked with Database lock instance.