### PR TITLE
Fixed #1657 - 2.0: calling Database.save(MutableDocument) with reusin…

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConcurrencyTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ConcurrencyTest.java
@@ -256,7 +256,7 @@ public class ConcurrencyTest extends BaseTest {
         final int kNDocs = 5;
         final int kNRounds = 50;
         final int kNThreads = 4;
-        final int kWaitInSec = 180;
+        final int kWaitInSec = 600;
 
         // createDocs2 returns synchronized List.
         final List<String> docIDs = createDocs(kNDocs, "Create");

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LoadTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LoadTest.java
@@ -324,10 +324,9 @@ public class LoadTest extends BaseTest {
         return true;
     }
 
-    // NOTE: not yet activated
-    // @Test
+    @Test
     public void testAddRevisions() {
-        final int revs = 10000;
+        final int revs = 1000;
         addRevisions(revs, false);
         addRevisions(revs, true);
     }

--- a/shared/src/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/shared/src/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -738,8 +738,8 @@ abstract class AbstractDatabase {
                 // Read the conflicting remote revision:
                 Document remoteDoc = new Document((Database) this, docID, true);
                 try {
-                    if(!remoteDoc.selectConflictingRevision()){
-                        Log.w(TAG, "Unable to select conflicting revision for '%s', skipping...",docID);
+                    if (!remoteDoc.selectConflictingRevision()) {
+                        Log.w(TAG, "Unable to select conflicting revision for '%s', skipping...", docID);
                         return;
                     }
                 } catch (LiteCoreException e) {
@@ -1086,13 +1086,15 @@ abstract class AbstractDatabase {
                 document.replaceC4Document(newDoc);
                 commit = true;
             } finally {
-                if (curDoc != null)
-                    curDoc.free();
+                if (curDoc != null) {
+                    curDoc.retain();
+                    curDoc.release(); // curDoc is not retained
+                }
                 try {
                     endTransaction(commit);// true: commit the transaction, false: abort the transaction
                 } catch (CouchbaseLiteException e) {
                     if (newDoc != null)
-                        newDoc.free();
+                        newDoc.release(); // newDoc is already retained
                     throw e;
                 }
             }


### PR DESCRIPTION
…g same MutableDocument 10000 times causes OOM.

- By reference counting, release the native memory more aggressively