### PR TITLE
Fixed #1660 - (Android) Upgrading CBL 1.x db. LiteCoreBridge.convertE…

### DIFF
--- a/android/CouchbaseLite/src/ce/java/com/couchbase/lite/DatabaseConfiguration.java
+++ b/android/CouchbaseLite/src/ce/java/com/couchbase/lite/DatabaseConfiguration.java
@@ -19,16 +19,21 @@ package com.couchbase.lite;
 
 import android.content.Context;
 
+import java.io.File;
+
 /**
  * Configuration for opening a database.
  */
 public final class DatabaseConfiguration {
+    private static final String TEMP_DIR_NAME = "tmp";
+
     //---------------------------------------------
     // member variables
     //---------------------------------------------
     private boolean readonly = false;
     private Context context = null;
     private String directory = null;
+    private boolean customDir = false;
 
     //---------------------------------------------
     // Constructors
@@ -40,6 +45,7 @@ public final class DatabaseConfiguration {
         this.readonly = false;
         this.context = context;
         this.directory = context.getFilesDir().getAbsolutePath();
+        this.customDir = false;
     }
 
     public DatabaseConfiguration(DatabaseConfiguration config) {
@@ -48,6 +54,7 @@ public final class DatabaseConfiguration {
         this.readonly = false;
         this.context = config.context;
         this.directory = config.directory;
+        this.customDir = config.customDir;
     }
 
     //---------------------------------------------
@@ -66,6 +73,7 @@ public final class DatabaseConfiguration {
         if (readonly)
             throw new IllegalStateException("DatabaseConfiguration is readonly mode.");
         this.directory = directory;
+        this.customDir = true;
         return this;
     }
 
@@ -93,6 +101,16 @@ public final class DatabaseConfiguration {
     }
 
     String getTempDir() {
-        return context.getCacheDir().getAbsolutePath();
+        if (customDir) {
+            File cache = new File(directory, TEMP_DIR_NAME);
+            if (!cache.exists())
+                if (!cache.mkdirs())
+                    return context.getCacheDir().getAbsolutePath();
+                else if (!cache.isDirectory())
+                    return context.getCacheDir().getAbsolutePath();
+            return cache.getAbsolutePath();
+        } else {
+            return context.getCacheDir().getAbsolutePath();
+        }
     }
 }


### PR DESCRIPTION
…xception

- Issue is caused by rename() system call because cache is in main filesystem and database directory is in sdcard which is different filesystem. In case of setting custom directory, set cache directory under it.