### PR TITLE
Fixed #1665 - Exception thrown openDatabase

### DIFF
--- a/android/CouchbaseLite/build.gradle
+++ b/android/CouchbaseLite/build.gradle
@@ -85,8 +85,9 @@ android {
     }
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+            consumerProguardFiles 'proguard-rules.pro'
             buildConfigField "int", "BUILD_NO", "$buildNo"
             buildConfigField "String", "GitHash", "\"${getGitHash()}\""
         }

--- a/android/CouchbaseLite/proguard-rules.pro
+++ b/android/CouchbaseLite/proguard-rules.pro
@@ -23,3 +23,15 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# OkHttp3
+-dontwarn okhttp3.**
+-dontwarn okio.**
+-dontwarn javax.annotation.**
+-dontwarn org.conscrypt.**
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# CBL2.x
+-keep class com.couchbase.litecore.**{ *; }
+-keep class com.couchbase.lite.**{ *; }


### PR DESCRIPTION
- Proguard strips Java classes/methods which are called from reflection or from native C/C++ codes
- Solution Added consumerProguardFiles setting