### PR TITLE
Fixes #1742 (emoji support)

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/JavaTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/JavaTest.java
@@ -49,6 +49,20 @@ public class JavaTest extends BaseTest {
         testRoundTrip(Math.PI);
     }
 
+    // https://github.com/couchbase/couchbase-lite-android/issues/1742
+    @Test
+    public void testDecodeEmoji() throws LiteCoreException {
+        // 0000: 44 f0 9f 98…: "😺"
+        // 0006: 80 03       : &"😺" (@0000)
+
+        byte[] realUtf8Data = new byte[] { (byte)0x44, (byte)0xF0, (byte)0x9F, (byte)0x98, (byte)0xBA,
+                (byte)0x00, (byte)0x80, (byte)0x03 };
+        FLValue flValue = FLValue.fromData(realUtf8Data);
+        assertNotNull(flValue);
+        Object obj = FLValue.toObject(flValue);
+        assertEquals("\uD83D\uDE3A", obj);
+    }
+
     private void testRoundTrip(Object item) throws LiteCoreException {
         Encoder encoder = new Encoder();
         assertNotNull(encoder);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/JavaTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/JavaTest.java
@@ -37,6 +37,7 @@ public class JavaTest extends BaseTest {
     // https://github.com/couchbase/couchbase-lite-android/issues/1453
     @Test
     public void testFLEncode() throws LiteCoreException {
+        testRoundTrip("Hello \uD83D\uDE3A World"); // 😺
         testRoundTrip(42L);
         testRoundTrip(Long.MIN_VALUE);
         testRoundTrip("Fleece");


### PR DESCRIPTION
The problem is not Android itself in this case, but normal UTF-8 received from other platforms.  The reverse would also be true (modified UTF-8 from Android would cause other platforms problems) so the answer is to convert to UTF-8 at write time and convert to modified at read time.  I think it might be better to actually convert to UTF-16 at read time since it will look like this:

UTF-8 -> UTF-16

Instead of this

UTF-8 -> modified UTF-8 -> UTF-16 (note that only required characters are converted, the rest are copied as is for the first step)

However, I'm going to leave it as the second since I'm unsure of the benefit, and the algorithm is more complicated than the one I have now.