### PR TITLE
Fix warning message when there is no digest nor content

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/Blob.java
+++ b/shared/src/main/java/com/couchbase/lite/Blob.java
@@ -187,7 +187,7 @@ public final class Blob implements FLEncodable {
             this.content = (byte[]) data;
 
         if (this.digest == null && this.content == null) {
-            Log.w(TAG, "Blob read from database has missing digest");
+            Log.w(TAG, "Blob read from database has neither digest nor data.");
             this.digest = "";
         }
     }


### PR DESCRIPTION
Changed the mssage to `Blob read from database has neither digest nor data`. This is inline with .NET.