### PR TITLE
test: add remaining file logging unit tests

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -1,6 +1,7 @@
 package com.couchbase.lite;
 
 import android.content.Context;
+import android.content.pm.ApplicationInfo;
 import android.support.test.InstrumentationRegistry;
 
 import com.couchbase.lite.internal.support.Log;
@@ -138,11 +139,16 @@ public class LogTest {
 
                 int maxRotateCount = config.getMaxRotateCount();
                 int totalFilesShouldBeInDirectory = (maxRotateCount + 1) * 5;
+                boolean isDebug = (
+                        (context.getApplicationInfo().flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0
+                );
+                if (!isDebug) {
+                    totalFilesShouldBeInDirectory -= 1;
+                }
                 int totalLogFilesSaved = path.listFiles().length;
                 assertEquals(totalFilesShouldBeInDirectory, totalLogFilesSaved);
             }
         });
-        emptyDirectory(path.getAbsolutePath());
     }
 
     @Test
@@ -174,7 +180,6 @@ public class LogTest {
                 }
             }
         });
-        emptyDirectory(path.getAbsolutePath());
     }
 
     @Test
@@ -226,10 +231,9 @@ public class LogTest {
                 }
             }
         });
-        emptyDirectory(path.getAbsolutePath());
     }
 
-    @Test @Ignore
+    @Test
     public void testFileLoggingHeader() {
         final File path = new File(
                 context.getCacheDir().getAbsolutePath(),
@@ -255,7 +259,6 @@ public class LogTest {
                 }
             }
         });
-        emptyDirectory(path.getAbsolutePath());
     }
 
     private void testWithConfiguration(LogLevel level, LogFileConfiguration config, Runnable r) {
@@ -276,7 +279,6 @@ public class LogTest {
             for (File log : f.listFiles()) {
                 log.delete();
             }
-            f.delete();
         }
         return path;
     }

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -6,15 +6,22 @@ import android.support.test.InstrumentationRegistry;
 import com.couchbase.lite.internal.support.Log;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
+import java.io.FilenameFilter;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class LogTest {
@@ -111,6 +118,146 @@ public class LogTest {
         assertEquals(4, customLogger.getLines().size());
     }
 
+    @Test @Ignore
+    public void testFileLoggingMaxSize() {
+        final File path = new File(
+                context.getCacheDir().getAbsolutePath(),
+                "testFileLoggingMaxSize"
+        );
+        final String logDirectory = emptyDirectory(path.getAbsolutePath());
+        final LogFileConfiguration config = new LogFileConfiguration(logDirectory)
+                .setUsePlaintext(true)
+                .setMaxSize(1024);
+
+        testWithConfiguration(LogLevel.DEBUG, config, new Runnable() {
+            @Override
+            public void run() {
+
+                // this should create two files, as the 1KB logs + extra header
+                writeOneKiloByteOfLog();
+
+                int maxRotateCount = config.getMaxRotateCount();
+                int totalFilesShouldBeInDirectory = (maxRotateCount + 1) * 5;
+                int totalLogFilesSaved = path.listFiles().length;
+                assertEquals(totalFilesShouldBeInDirectory, totalLogFilesSaved);
+            }
+        });
+        emptyDirectory(path.getAbsolutePath());
+    }
+
+    @Test
+    public void testFileLoggingDisableLogging() {
+        final File path = new File(
+                context.getCacheDir().getAbsolutePath(),
+                "testFileLoggingDisableLogging"
+        );
+        final String logDirectory = emptyDirectory(path.getAbsolutePath());
+        final LogFileConfiguration config = new LogFileConfiguration(logDirectory)
+                .setUsePlaintext(true);
+        testWithConfiguration(LogLevel.NONE, config, new Runnable() {
+            @Override
+            public void run() {
+                String uuidString = UUID.randomUUID().toString();
+                writeAllLogs(uuidString);
+
+                try {
+                    for (File log : path.listFiles()) {
+                        byte[] encoded = Files.readAllBytes(log.toPath());
+                        String contents = new String(
+                                encoded,
+                                StandardCharsets.US_ASCII
+                        );
+                        assertFalse(contents.contains(uuidString));
+                    }
+                } catch(Exception e) {
+                    fail("Exception during test callback " + e.toString());
+                }
+            }
+        });
+        emptyDirectory(path.getAbsolutePath());
+    }
+
+    @Test
+    public void testFileLoggingReEnableLogging() {
+        final File path = new File(
+                context.getCacheDir().getAbsolutePath(),
+                "testFileLoggingReEnableLogging"
+        );
+        final String logDirectory = emptyDirectory(path.getAbsolutePath());
+        LogFileConfiguration config = new LogFileConfiguration(logDirectory)
+                .setUsePlaintext(true);
+        testWithConfiguration(LogLevel.NONE, config, new Runnable() {
+            @Override
+            public void run() {
+                String uuidString = UUID.randomUUID().toString();
+                writeAllLogs(uuidString);
+
+                try {
+                    for (File log : path.listFiles()) {
+                        byte[] encoded = Files.readAllBytes(log.toPath());
+                        String contents = new String(
+                                encoded,
+                                StandardCharsets.US_ASCII
+                        );
+                        assertFalse(contents.contains(uuidString));
+                    }
+
+                    Database.log.getFile().setLevel(LogLevel.VERBOSE);
+                    writeAllLogs(uuidString);
+
+                    File[] filesExceptDebug = path.listFiles(new FilenameFilter() {
+                        @Override
+                        public boolean accept(File dir, String name) {
+                            return !name.toLowerCase().startsWith("cbl_debug_");
+                        }
+                    });
+
+                    for (File log : filesExceptDebug) {
+                        byte[] encoded = Files.readAllBytes(log.toPath());
+                        String contents = new String(
+                                encoded,
+                                StandardCharsets.US_ASCII
+                        );
+                        assertTrue(contents.contains(uuidString));
+                    }
+
+                } catch(Exception e) {
+                    fail("Exception during test callback " + e.toString());
+                }
+            }
+        });
+        emptyDirectory(path.getAbsolutePath());
+    }
+
+    @Test @Ignore
+    public void testFileLoggingHeader() {
+        final File path = new File(
+                context.getCacheDir().getAbsolutePath(),
+                "testFileLoggingHeader"
+        );
+        final String logDirectory = emptyDirectory(path.getAbsolutePath());
+        LogFileConfiguration config = new LogFileConfiguration(logDirectory)
+                .setUsePlaintext(true);
+        testWithConfiguration(LogLevel.VERBOSE, config, new Runnable() {
+            @Override
+            public void run() {
+                writeOneKiloByteOfLog();
+
+                try {
+                    for (File log : path.listFiles()) {
+                        String firstLine = Files.readAllLines(log.toPath()).get(0);
+                        assertTrue(firstLine.contains("CouchbaseLite/"));
+                        assertTrue(firstLine.contains("Build/"));
+                        assertTrue(firstLine.contains("Commit/"));
+                    }
+                } catch(Exception e) {
+                    fail("Exception during test callback " + e.toString());
+                }
+            }
+        });
+        emptyDirectory(path.getAbsolutePath());
+    }
+
     private void testWithConfiguration(LogLevel level, LogFileConfiguration config, Runnable r) {
         LogFileConfiguration old = Database.log.getFile().getConfig();
         Database.log.getFile().setConfig(config);
@@ -129,9 +276,23 @@ public class LogTest {
             for (File log : f.listFiles()) {
                 log.delete();
             }
+            f.delete();
         }
-
         return path;
+    }
+
+    private static void writeOneKiloByteOfLog() {
+        String message = "11223344556677889900"; // ~43 bytes
+        for (int i = 0; i < 24; i++) { // 24 * 43 = 1032
+            writeAllLogs(message);
+        }
+    }
+
+    private static void writeAllLogs(String message) {
+        Log.v(LogDomain.DATABASE.toString(), message);
+        Log.i(LogDomain.DATABASE.toString(), message);
+        Log.w(LogDomain.DATABASE.toString(), message);
+        Log.e(LogDomain.DATABASE.toString(), message);
     }
 }
 


### PR DESCRIPTION
* check for file max size
* check for disable, reenable logging
* check for file header.

* note: file max size is not working, as the debug file is not printing anything in it.
* note: file header also not printing, seems like user agent is not passed to FileOptions in JNI

link: #1808