### PR TITLE
Feature/query clause validate null

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
@@ -685,32 +685,6 @@ public class QueryTest extends BaseTest {
     }
 
     @Test
-    public void testGroupByHavingNull() {
-        DataSource ds = DataSource.database(this.db);
-
-        Expression animal = Expression.property("animal");
-        Expression subject = Expression.property("subject");
-
-        SelectResult rsId = SelectResult.property("id");
-
-        Expression groupByExpr = animal;
-        Ordering ordering = Ordering.expression(animal);
-
-        try {
-            Query q = QueryBuilder
-                    .select(rsId)
-                    .from(ds)
-                    .where(subject.equalTo(Expression.string("biology")))
-                    .groupBy(groupByExpr)
-                    .having(null)
-                    .orderBy(ordering);
-        } catch (Exception ex) {
-            assertEquals(ex.getMessage(),
-                    "Expression parameter cannot be null in Having clause.");
-        }
-    }
-
-    @Test
     public void testParameters() throws Exception {
         loadNumbers(100);
 

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
@@ -685,6 +685,32 @@ public class QueryTest extends BaseTest {
     }
 
     @Test
+    public void testGroupByHavingNull() {
+        DataSource ds = DataSource.database(this.db);
+
+        Expression animal = Expression.property("animal");
+        Expression subject = Expression.property("subject");
+
+        SelectResult rsId = SelectResult.property("id");
+
+        Expression groupByExpr = animal;
+        Ordering ordering = Ordering.expression(animal);
+
+        try {
+            Query q = QueryBuilder
+                    .select(rsId)
+                    .from(ds)
+                    .where(subject.equalTo(Expression.string("biology")))
+                    .groupBy(groupByExpr)
+                    .having(null)
+                    .orderBy(ordering);
+        } catch (Exception ex) {
+            assertEquals(ex.getMessage(),
+                    "Expression parameter cannot be null in Having clause.");
+        }
+    }
+
+    @Test
     public void testParameters() throws Exception {
         loadNumbers(100);
 

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
@@ -1300,7 +1300,6 @@ public class QueryTest extends BaseTest {
 
         Query q = QueryBuilder.select(S_STRING)
                 .from(DataSource.database(db))
-                .where(null)
                 .orderBy(Ordering.expression(STRING.collate(NO_LOCALE)));
 
         final String[] expected = {"A", "Å", "B", "Z"};
@@ -1322,7 +1321,6 @@ public class QueryTest extends BaseTest {
 
             q = QueryBuilder.select(S_STRING)
                     .from(DataSource.database(db))
-                    .where(null)
                     .orderBy(Ordering.expression(STRING.collate(WITH_LOCALE)));
 
             final String[] expected2 = {"A", "Å", "B", "Z"};
@@ -1345,7 +1343,6 @@ public class QueryTest extends BaseTest {
 
             q = QueryBuilder.select(S_STRING)
                     .from(DataSource.database(db))
-                    .where(null)
                     .orderBy(Ordering.expression(STRING.collate(WITH_LOCALE)));
 
             final String[] expected2 = {"A", "B", "Z", "Å"};

--- a/shared/src/main/java/com/couchbase/lite/DataSource.java
+++ b/shared/src/main/java/com/couchbase/lite/DataSource.java
@@ -56,12 +56,10 @@ public class DataSource {
          *
          * @param alias the alias to set.
          * @return the data source object with the given alias set.
-         * @throws IllegalArgumentException when alias is null.
          */
         public DataSource as(@NonNull String alias) {
-
-            if(alias == null) {
-                throw new IllegalArgumentException("alias is null");
+            if (alias == null) {
+                throw new IllegalArgumentException("alias is null.");
             }
             super.alias = alias;
             return this;
@@ -85,12 +83,10 @@ public class DataSource {
      *
      * @param database the database used as a source of data for query.
      * @return {@code DataSource.Database} object.
-     * @throws IllegalArgumentException when database is null.
      */
     public static As database(@NonNull com.couchbase.lite.Database database) {
-
-        if(database == null) {
-            throw new IllegalArgumentException("database is null");
+        if (database == null) {
+            throw new IllegalArgumentException("database is null.");
         }
         return new As(database);
     }

--- a/shared/src/main/java/com/couchbase/lite/DataSource.java
+++ b/shared/src/main/java/com/couchbase/lite/DataSource.java
@@ -85,8 +85,13 @@ public class DataSource {
      *
      * @param database the database used as a source of data for query.
      * @return {@code DataSource.Database} object.
+     * @throws IllegalArgumentException when database is null.
      */
-    public static As database(com.couchbase.lite.Database database) {
+    public static As database(@NonNull com.couchbase.lite.Database database) {
+
+        if(database == null) {
+            throw new IllegalArgumentException("database is null");
+        }
         return new As(database);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/DataSource.java
+++ b/shared/src/main/java/com/couchbase/lite/DataSource.java
@@ -17,6 +17,8 @@
 //
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -54,8 +56,13 @@ public class DataSource {
          *
          * @param alias the alias to set.
          * @return the data source object with the given alias set.
+         * @throws IllegalArgumentException when alias is null.
          */
-        public DataSource as(String alias) {
+        public DataSource as(@NonNull String alias) {
+
+            if(alias == null) {
+                throw new IllegalArgumentException("alias is null");
+            }
             super.alias = alias;
             return this;
         }

--- a/shared/src/main/java/com/couchbase/lite/From.java
+++ b/shared/src/main/java/com/couchbase/lite/From.java
@@ -47,7 +47,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      * @throws IllegalArgumentException when joins is null.
      */
     @Override
-    public Joins join(Join... joins) {
+    public Joins join(@NonNull Join... joins) {
 
         if(joins == null) {
             throw new IllegalArgumentException("joins is null");

--- a/shared/src/main/java/com/couchbase/lite/From.java
+++ b/shared/src/main/java/com/couchbase/lite/From.java
@@ -18,6 +18,8 @@
 
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.Arrays;
 
 /**
@@ -59,7 +61,10 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      * @return the WHERE component.
      */
     @Override
-    public Where where(Expression expression) {
+    public Where where(@NonNull Expression expression) {
+        if(expression == null) {
+            throw new IllegalArgumentException("expression is null");
+        }
         return new Where(this, expression);
     }
 
@@ -74,7 +79,10 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      * @return The GroupBy object that represents the GROUP BY clause of the query.
      */
     @Override
-    public GroupBy groupBy(Expression... expressions) {
+    public GroupBy groupBy(@NonNull Expression... expressions) {
+        if(expressions == null) {
+            throw new IllegalArgumentException("expressions is null");
+        }
         return new GroupBy(this, Arrays.asList(expressions));
     }
 
@@ -89,7 +97,10 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      * @return the ORDER BY component.
      */
     @Override
-    public OrderBy orderBy(Ordering... orderings) {
+    public OrderBy orderBy(@NonNull Ordering... orderings) {
+        if(orderings == null) {
+            throw new IllegalArgumentException("orderings is null");
+        }
         return new OrderBy(this, Arrays.asList(orderings));
     }
 
@@ -104,7 +115,10 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      * @return The Limit object that represents the LIMIT clause of the query.
      */
     @Override
-    public Limit limit(Expression limit) {
+    public Limit limit(@NonNull Expression limit) {
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, null);
     }
 
@@ -117,7 +131,10 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      * @return The Limit object that represents the LIMIT clause of the query.
      */
     @Override
-    public Limit limit(Expression limit, Expression offset) {
+    public Limit limit(@NonNull Expression limit, Expression offset) {
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, offset);
     }
 }

--- a/shared/src/main/java/com/couchbase/lite/From.java
+++ b/shared/src/main/java/com/couchbase/lite/From.java
@@ -59,6 +59,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param expression the WHERE clause expression.
      * @return the WHERE component.
+     * @throws IllegalArgumentException when expression is null.
      */
     @Override
     public Where where(@NonNull Expression expression) {
@@ -78,6 +79,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param expressions The group by expression.
      * @return The GroupBy object that represents the GROUP BY clause of the query.
+     * @throws IllegalArgumentException when expressions is null.
      */
     @Override
     public GroupBy groupBy(@NonNull Expression... expressions) {
@@ -97,6 +99,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param orderings an array of the ORDER BY expressions.
      * @return the ORDER BY component.
+     * @throws IllegalArgumentException when orderings is null.
      */
     @Override
     public OrderBy orderBy(@NonNull Ordering... orderings) {
@@ -116,6 +119,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param limit The limit expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit) {
@@ -133,6 +137,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      * @param limit  The limit expression.
      * @param offset The offset expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit, Expression offset) {

--- a/shared/src/main/java/com/couchbase/lite/From.java
+++ b/shared/src/main/java/com/couchbase/lite/From.java
@@ -62,6 +62,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      */
     @Override
     public Where where(@NonNull Expression expression) {
+
         if(expression == null) {
             throw new IllegalArgumentException("expression is null");
         }
@@ -80,6 +81,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      */
     @Override
     public GroupBy groupBy(@NonNull Expression... expressions) {
+
         if(expressions == null) {
             throw new IllegalArgumentException("expressions is null");
         }
@@ -98,6 +100,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      */
     @Override
     public OrderBy orderBy(@NonNull Ordering... orderings) {
+
         if(orderings == null) {
             throw new IllegalArgumentException("orderings is null");
         }
@@ -116,6 +119,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      */
     @Override
     public Limit limit(@NonNull Expression limit) {
+
         if(limit == null) {
             throw new IllegalArgumentException("limit is null");
         }
@@ -132,6 +136,7 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      */
     @Override
     public Limit limit(@NonNull Expression limit, Expression offset) {
+        
         if(limit == null) {
             throw new IllegalArgumentException("limit is null");
         }

--- a/shared/src/main/java/com/couchbase/lite/From.java
+++ b/shared/src/main/java/com/couchbase/lite/From.java
@@ -44,9 +44,14 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param joins The Join objects.
      * @return The Joins object that represents the JOIN clause of the query.
+     * @throws IllegalArgumentException when joins is null.
      */
     @Override
     public Joins join(Join... joins) {
+
+        if(joins == null) {
+            throw new IllegalArgumentException("joins is null");
+        }
         return new Joins(this, Arrays.asList(joins));
     }
 

--- a/shared/src/main/java/com/couchbase/lite/From.java
+++ b/shared/src/main/java/com/couchbase/lite/From.java
@@ -44,13 +44,11 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param joins The Join objects.
      * @return The Joins object that represents the JOIN clause of the query.
-     * @throws IllegalArgumentException when joins is null.
      */
     @Override
     public Joins join(@NonNull Join... joins) {
-
-        if(joins == null) {
-            throw new IllegalArgumentException("joins is null");
+        if (joins == null) {
+            throw new IllegalArgumentException("joins is null.");
         }
         return new Joins(this, Arrays.asList(joins));
     }
@@ -64,13 +62,11 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param expression the WHERE clause expression.
      * @return the WHERE component.
-     * @throws IllegalArgumentException when expression is null.
      */
     @Override
     public Where where(@NonNull Expression expression) {
-
-        if(expression == null) {
-            throw new IllegalArgumentException("expression is null");
+        if (expression == null) {
+            throw new IllegalArgumentException("expression is null.");
         }
         return new Where(this, expression);
     }
@@ -84,13 +80,11 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param expressions The group by expression.
      * @return The GroupBy object that represents the GROUP BY clause of the query.
-     * @throws IllegalArgumentException when expressions is null.
      */
     @Override
     public GroupBy groupBy(@NonNull Expression... expressions) {
-
-        if(expressions == null) {
-            throw new IllegalArgumentException("expressions is null");
+        if (expressions == null) {
+            throw new IllegalArgumentException("expressions is null.");
         }
         return new GroupBy(this, Arrays.asList(expressions));
     }
@@ -104,13 +98,11 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param orderings an array of the ORDER BY expressions.
      * @return the ORDER BY component.
-     * @throws IllegalArgumentException when orderings is null.
      */
     @Override
     public OrderBy orderBy(@NonNull Ordering... orderings) {
-
         if(orderings == null) {
-            throw new IllegalArgumentException("orderings is null");
+            throw new IllegalArgumentException("orderings is null.");
         }
         return new OrderBy(this, Arrays.asList(orderings));
     }
@@ -124,13 +116,11 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      *
      * @param limit The limit expression.
      * @return The Limit object that represents the LIMIT clause of the query.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, null);
     }
@@ -142,13 +132,11 @@ public final class From extends AbstractQuery implements JoinRouter, WhereRouter
      * @param limit  The limit expression.
      * @param offset The offset expression.
      * @return The Limit object that represents the LIMIT clause of the query.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit, Expression offset) {
-        
         if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, offset);
     }

--- a/shared/src/main/java/com/couchbase/lite/GroupBy.java
+++ b/shared/src/main/java/com/couchbase/lite/GroupBy.java
@@ -53,13 +53,11 @@ public final class GroupBy extends AbstractQuery implements HavingRouter, OrderB
      *
      * @param expression The expression
      * @return The Having object that represents the HAVING clause of the query.
-     * @throws IllegalArgumentException when expression is null.
      */
     @Override
     public Having having(@NonNull Expression expression) {
-
-        if(expression == null) {
-            throw new IllegalArgumentException("expression is null");
+        if (expression == null) {
+            throw new IllegalArgumentException("expression is null.");
         }
         return new Having(this, expression);
     }
@@ -73,13 +71,11 @@ public final class GroupBy extends AbstractQuery implements HavingRouter, OrderB
      *
      * @param orderings an array of the ORDER BY expressions.
      * @return the ORDER BY component.
-     * @throws IllegalArgumentException when orderings is null.
      */
     @Override
     public OrderBy orderBy(@NonNull Ordering... orderings) {
-
-        if(orderings == null) {
-            throw new IllegalArgumentException("orderings is null");
+        if (orderings == null) {
+            throw new IllegalArgumentException("orderings is null.");
         }
         return new OrderBy(this, Arrays.asList(orderings));
     }
@@ -97,9 +93,8 @@ public final class GroupBy extends AbstractQuery implements HavingRouter, OrderB
      */
     @Override
     public Limit limit(@NonNull Expression limit) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, null);
     }
@@ -115,9 +110,8 @@ public final class GroupBy extends AbstractQuery implements HavingRouter, OrderB
      */
     @Override
     public Limit limit(@NonNull Expression limit, Expression offset) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, offset);
     }

--- a/shared/src/main/java/com/couchbase/lite/GroupBy.java
+++ b/shared/src/main/java/com/couchbase/lite/GroupBy.java
@@ -51,9 +51,13 @@ public final class GroupBy extends AbstractQuery implements HavingRouter, OrderB
      *
      * @param expression The expression
      * @return The Having object that represents the HAVING clause of the query.
+     * @throws RuntimeException when Expression parameter is null.
      */
     @Override
     public Having having(Expression expression) {
+        if(expression == null) {
+            throw new RuntimeException("Expression parameter cannot be null in Having clause.");
+        }
         return new Having(this, expression);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/GroupBy.java
+++ b/shared/src/main/java/com/couchbase/lite/GroupBy.java
@@ -17,6 +17,8 @@
 //
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -51,12 +53,13 @@ public final class GroupBy extends AbstractQuery implements HavingRouter, OrderB
      *
      * @param expression The expression
      * @return The Having object that represents the HAVING clause of the query.
-     * @throws RuntimeException when Expression parameter is null.
+     * @throws IllegalArgumentException when expression is null.
      */
     @Override
-    public Having having(Expression expression) {
+    public Having having(@NonNull Expression expression) {
+
         if(expression == null) {
-            throw new RuntimeException("Expression parameter cannot be null in Having clause.");
+            throw new IllegalArgumentException("expression is null");
         }
         return new Having(this, expression);
     }
@@ -70,9 +73,14 @@ public final class GroupBy extends AbstractQuery implements HavingRouter, OrderB
      *
      * @param orderings an array of the ORDER BY expressions.
      * @return the ORDER BY component.
+     * @throws IllegalArgumentException when orderings is null.
      */
     @Override
-    public OrderBy orderBy(Ordering... orderings) {
+    public OrderBy orderBy(@NonNull Ordering... orderings) {
+
+        if(orderings == null) {
+            throw new IllegalArgumentException("orderings is null");
+        }
         return new OrderBy(this, Arrays.asList(orderings));
     }
 
@@ -85,9 +93,14 @@ public final class GroupBy extends AbstractQuery implements HavingRouter, OrderB
      *
      * @param limit The limit expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit) {
+    public Limit limit(@NonNull Expression limit) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, null);
     }
 
@@ -98,9 +111,14 @@ public final class GroupBy extends AbstractQuery implements HavingRouter, OrderB
      * @param limit  The limit expression.
      * @param offset The offset expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit, Expression offset) {
+    public Limit limit(@NonNull Expression limit, Expression offset) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, offset);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/Having.java
+++ b/shared/src/main/java/com/couchbase/lite/Having.java
@@ -17,6 +17,8 @@
 //
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.Arrays;
 
 /**
@@ -50,7 +52,7 @@ public final class Having extends AbstractQuery implements OrderByRouter, LimitR
      * @throws IllegalArgumentException when orderings is null.
      */
     @Override
-    public OrderBy orderBy(Ordering... orderings) {
+    public OrderBy orderBy(@NonNull Ordering... orderings) {
 
         if(orderings == null) {
             throw new IllegalArgumentException("orderings is null");
@@ -70,7 +72,7 @@ public final class Having extends AbstractQuery implements OrderByRouter, LimitR
      * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit) {
+    public Limit limit(@NonNull Expression limit) {
 
         if(limit == null) {
             throw new IllegalArgumentException("limit is null");
@@ -88,7 +90,7 @@ public final class Having extends AbstractQuery implements OrderByRouter, LimitR
      * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit, Expression offset) {
+    public Limit limit(@NonNull Expression limit, Expression offset) {
 
         if(limit == null) {
             throw new IllegalArgumentException("limit is null");

--- a/shared/src/main/java/com/couchbase/lite/Having.java
+++ b/shared/src/main/java/com/couchbase/lite/Having.java
@@ -49,13 +49,11 @@ public final class Having extends AbstractQuery implements OrderByRouter, LimitR
      *
      * @param orderings an array of the ORDER BY expressions.
      * @return the ORDER BY component.
-     * @throws IllegalArgumentException when orderings is null.
      */
     @Override
     public OrderBy orderBy(@NonNull Ordering... orderings) {
-
-        if(orderings == null) {
-            throw new IllegalArgumentException("orderings is null");
+        if (orderings == null) {
+            throw new IllegalArgumentException("orderings is null.");
         }
         return new OrderBy(this, Arrays.asList(orderings));
     }
@@ -69,13 +67,11 @@ public final class Having extends AbstractQuery implements OrderByRouter, LimitR
      *
      * @param limit The limit expression.
      * @return The Limit object that represents the LIMIT clause of the query.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, null);
     }
@@ -87,13 +83,11 @@ public final class Having extends AbstractQuery implements OrderByRouter, LimitR
      * @param limit  The limit expression.
      * @param offset The offset expression.
      * @return The Limit object that represents the LIMIT clause of the query.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit, Expression offset) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, offset);
     }

--- a/shared/src/main/java/com/couchbase/lite/Having.java
+++ b/shared/src/main/java/com/couchbase/lite/Having.java
@@ -44,9 +44,17 @@ public final class Having extends AbstractQuery implements OrderByRouter, LimitR
 
     /**
      * Create and chain an ORDER BY component for specifying the orderings of the query result.
+     *
+     * @param orderings an array of the ORDER BY expressions.
+     * @return the ORDER BY component.
+     * @throws IllegalArgumentException when orderings is null.
      */
     @Override
     public OrderBy orderBy(Ordering... orderings) {
+
+        if(orderings == null) {
+            throw new IllegalArgumentException("orderings is null");
+        }
         return new OrderBy(this, Arrays.asList(orderings));
     }
 
@@ -59,9 +67,14 @@ public final class Having extends AbstractQuery implements OrderByRouter, LimitR
      *
      * @param limit The limit expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(Expression limit) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, null);
     }
 
@@ -72,9 +85,14 @@ public final class Having extends AbstractQuery implements OrderByRouter, LimitR
      * @param limit  The limit expression.
      * @param offset The offset expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(Expression limit, Expression offset) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, offset);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/Join.java
+++ b/shared/src/main/java/com/couchbase/lite/Join.java
@@ -69,12 +69,10 @@ public class Join {
          *
          * @param expression The Expression object specifying the join conditions.
          * @return The Join object that represents a single JOIN clause of the query.
-         * @throws IllegalArgumentException when expression is null.
          */
         public Join on(@NonNull Expression expression) {
-
-            if(expression == null) {
-                throw new IllegalArgumentException("expression is null");
+            if (expression == null) {
+                throw new IllegalArgumentException("expression is null.");
             }
             this.on = expression;
             return this;
@@ -111,12 +109,10 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The On object used for specifying join conditions.
-     * @throws IllegalArgumentException when datasource is null.
      */
     public static On join(@NonNull DataSource datasource) {
-
-        if(datasource == null) {
-            throw new IllegalArgumentException("datasource is null");
+        if (datasource == null) {
+            throw new IllegalArgumentException("datasource is null.");
         }
         return innerJoin(datasource);
     }
@@ -127,12 +123,10 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The On object used for specifying join conditions.
-     * @throws IllegalArgumentException when datasource is null.
      */
     public static On leftJoin(@NonNull DataSource datasource) {
-
-        if(datasource == null) {
-            throw new IllegalArgumentException("datasource is null");
+        if (datasource == null) {
+            throw new IllegalArgumentException("datasource is null.");
         }
         return new On(kCBLLeftOuterJoin, datasource);
     }
@@ -143,12 +137,10 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The On object used for specifying join conditions.
-     * @throws IllegalArgumentException when datasource is null.
      */
     public static On leftOuterJoin(@NonNull DataSource datasource) {
-
-        if(datasource == null) {
-            throw new IllegalArgumentException("datasource is null");
+        if (datasource == null) {
+            throw new IllegalArgumentException("datasource is null.");
         }
         return new On(kCBLLeftOuterJoin, datasource);
     }
@@ -159,12 +151,10 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The On object used for specifying join conditions.
-     * @throws IllegalArgumentException when datasource is null.
      */
     public static On innerJoin(@NonNull DataSource datasource) {
-
-        if(datasource == null) {
-            throw new IllegalArgumentException("datasource is null");
+        if (datasource == null) {
+            throw new IllegalArgumentException("datasource is null.");
         }
         return new On(kCBLInnerJoin, datasource);
     }
@@ -175,12 +165,10 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The Join object used for specifying join conditions.
-     * @throws IllegalArgumentException when datasource is null.
      */
     public static Join crossJoin(@NonNull DataSource datasource) {
-
-        if(datasource == null) {
-            throw new IllegalArgumentException("datasource is null");
+        if (datasource == null) {
+            throw new IllegalArgumentException("datasource is null.");
         }
         return new Join(kCBLCrossJoin, datasource);
     }

--- a/shared/src/main/java/com/couchbase/lite/Join.java
+++ b/shared/src/main/java/com/couchbase/lite/Join.java
@@ -113,7 +113,7 @@ public class Join {
      * @return The On object used for specifying join conditions.
      * @throws IllegalArgumentException when datasource is null.
      */
-    public static On join(DataSource datasource) {
+    public static On join(@NonNull DataSource datasource) {
 
         if(datasource == null) {
             throw new IllegalArgumentException("datasource is null");
@@ -129,7 +129,7 @@ public class Join {
      * @return The On object used for specifying join conditions.
      * @throws IllegalArgumentException when datasource is null.
      */
-    public static On leftJoin(DataSource datasource) {
+    public static On leftJoin(@NonNull DataSource datasource) {
 
         if(datasource == null) {
             throw new IllegalArgumentException("datasource is null");
@@ -145,7 +145,7 @@ public class Join {
      * @return The On object used for specifying join conditions.
      * @throws IllegalArgumentException when datasource is null.
      */
-    public static On leftOuterJoin(DataSource datasource) {
+    public static On leftOuterJoin(@NonNull DataSource datasource) {
 
         if(datasource == null) {
             throw new IllegalArgumentException("datasource is null");
@@ -161,7 +161,7 @@ public class Join {
      * @return The On object used for specifying join conditions.
      * @throws IllegalArgumentException when datasource is null.
      */
-    public static On innerJoin(DataSource datasource) {
+    public static On innerJoin(@NonNull DataSource datasource) {
 
         if(datasource == null) {
             throw new IllegalArgumentException("datasource is null");
@@ -177,7 +177,7 @@ public class Join {
      * @return The Join object used for specifying join conditions.
      * @throws IllegalArgumentException when datasource is null.
      */
-    public static Join crossJoin(DataSource datasource) {
+    public static Join crossJoin(@NonNull DataSource datasource) {
 
         if(datasource == null) {
             throw new IllegalArgumentException("datasource is null");

--- a/shared/src/main/java/com/couchbase/lite/Join.java
+++ b/shared/src/main/java/com/couchbase/lite/Join.java
@@ -17,6 +17,8 @@
 //
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -67,8 +69,13 @@ public class Join {
          *
          * @param expression The Expression object specifying the join conditions.
          * @return The Join object that represents a single JOIN clause of the query.
+         * @throws IllegalArgumentException when expression is null.
          */
-        public Join on(Expression expression) {
+        public Join on(@NonNull Expression expression) {
+
+            if(expression == null) {
+                throw new IllegalArgumentException("expression is null");
+            }
             this.on = expression;
             return this;
         }
@@ -104,8 +111,13 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The On object used for specifying join conditions.
+     * @throws IllegalArgumentException when datasource is null.
      */
     public static On join(DataSource datasource) {
+
+        if(datasource == null) {
+            throw new IllegalArgumentException("datasource is null");
+        }
         return innerJoin(datasource);
     }
 
@@ -115,8 +127,13 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The On object used for specifying join conditions.
+     * @throws IllegalArgumentException when datasource is null.
      */
     public static On leftJoin(DataSource datasource) {
+
+        if(datasource == null) {
+            throw new IllegalArgumentException("datasource is null");
+        }
         return new On(kCBLLeftOuterJoin, datasource);
     }
 
@@ -126,8 +143,13 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The On object used for specifying join conditions.
+     * @throws IllegalArgumentException when datasource is null.
      */
     public static On leftOuterJoin(DataSource datasource) {
+
+        if(datasource == null) {
+            throw new IllegalArgumentException("datasource is null");
+        }
         return new On(kCBLLeftOuterJoin, datasource);
     }
 
@@ -137,8 +159,13 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The On object used for specifying join conditions.
+     * @throws IllegalArgumentException when datasource is null.
      */
     public static On innerJoin(DataSource datasource) {
+
+        if(datasource == null) {
+            throw new IllegalArgumentException("datasource is null");
+        }
         return new On(kCBLInnerJoin, datasource);
     }
 
@@ -148,8 +175,13 @@ public class Join {
      *
      * @param datasource The DataSource object of the JOIN clause.
      * @return The Join object used for specifying join conditions.
+     * @throws IllegalArgumentException when datasource is null.
      */
     public static Join crossJoin(DataSource datasource) {
+
+        if(datasource == null) {
+            throw new IllegalArgumentException("datasource is null");
+        }
         return new Join(kCBLCrossJoin, datasource);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/Joins.java
+++ b/shared/src/main/java/com/couchbase/lite/Joins.java
@@ -48,9 +48,14 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      *
      * @param expression The where expression.
      * @return The Where object that represents the WHERE clause of the query.
+     * @throws IllegalArgumentException when expression is null.
      */
     @Override
     public Where where(Expression expression) {
+
+        if(expression == null) {
+            throw new IllegalArgumentException("expression is null");
+        }
         return new Where(this, expression);
     }
 
@@ -63,9 +68,14 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      *
      * @param orderings The Ordering objects.
      * @return The OrderBy object that represents the ORDER BY clause of the query.
+     * @throws IllegalArgumentException when orderings are null.
      */
     @Override
     public OrderBy orderBy(Ordering... orderings) {
+
+        if(orderings == null) {
+            throw new IllegalArgumentException("orderings is null");
+        }
         return new OrderBy(this, Arrays.asList(orderings));
     }
 
@@ -78,9 +88,14 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      *
      * @param limit The limit expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(Expression limit) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, null);
     }
 
@@ -91,9 +106,14 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      * @param limit  The limit expression.
      * @param offset The offset expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(Expression limit, Expression offset) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, offset);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/Joins.java
+++ b/shared/src/main/java/com/couchbase/lite/Joins.java
@@ -50,13 +50,11 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      *
      * @param expression The where expression.
      * @return The Where object that represents the WHERE clause of the query.
-     * @throws IllegalArgumentException when expression is null.
      */
     @Override
     public Where where(@NonNull Expression expression) {
-
-        if(expression == null) {
-            throw new IllegalArgumentException("expression is null");
+        if (expression == null) {
+            throw new IllegalArgumentException("expression is null.");
         }
         return new Where(this, expression);
     }
@@ -70,13 +68,11 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      *
      * @param orderings The Ordering objects.
      * @return The OrderBy object that represents the ORDER BY clause of the query.
-     * @throws IllegalArgumentException when orderings are null.
      */
     @Override
     public OrderBy orderBy(@NonNull Ordering... orderings) {
-
-        if(orderings == null) {
-            throw new IllegalArgumentException("orderings is null");
+        if (orderings == null) {
+            throw new IllegalArgumentException("orderings is null.");
         }
         return new OrderBy(this, Arrays.asList(orderings));
     }
@@ -90,13 +86,11 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      *
      * @param limit The limit expression.
      * @return The Limit object that represents the LIMIT clause of the query.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, null);
     }
@@ -108,13 +102,11 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      * @param limit  The limit expression.
      * @param offset The offset expression.
      * @return The Limit object that represents the LIMIT clause of the query.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit, Expression offset) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, offset);
     }

--- a/shared/src/main/java/com/couchbase/lite/Joins.java
+++ b/shared/src/main/java/com/couchbase/lite/Joins.java
@@ -17,6 +17,8 @@
 //
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -51,7 +53,7 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      * @throws IllegalArgumentException when expression is null.
      */
     @Override
-    public Where where(Expression expression) {
+    public Where where(@NonNull Expression expression) {
 
         if(expression == null) {
             throw new IllegalArgumentException("expression is null");
@@ -71,7 +73,7 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      * @throws IllegalArgumentException when orderings are null.
      */
     @Override
-    public OrderBy orderBy(Ordering... orderings) {
+    public OrderBy orderBy(@NonNull Ordering... orderings) {
 
         if(orderings == null) {
             throw new IllegalArgumentException("orderings is null");
@@ -91,7 +93,7 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit) {
+    public Limit limit(@NonNull Expression limit) {
 
         if(limit == null) {
             throw new IllegalArgumentException("limit is null");
@@ -109,7 +111,7 @@ public final class Joins extends AbstractQuery implements WhereRouter, OrderByRo
      * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit, Expression offset) {
+    public Limit limit(@NonNull Expression limit, Expression offset) {
 
         if(limit == null) {
             throw new IllegalArgumentException("limit is null");

--- a/shared/src/main/java/com/couchbase/lite/OrderBy.java
+++ b/shared/src/main/java/com/couchbase/lite/OrderBy.java
@@ -18,6 +18,8 @@
 
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,9 +52,14 @@ public final class OrderBy extends AbstractQuery implements LimitRouter {
      *
      * @param limit The limit expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit) {
+    public Limit limit(@NonNull Expression limit) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, null);
     }
 
@@ -62,9 +69,14 @@ public final class OrderBy extends AbstractQuery implements LimitRouter {
      * @param limit  The limit expression.
      * @param offset The offset expression.
      * @return The Limit object that represents the LIMIT clause of the query.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit, Expression offset) {
+    public Limit limit(@NonNull Expression limit, Expression offset) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, offset);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/OrderBy.java
+++ b/shared/src/main/java/com/couchbase/lite/OrderBy.java
@@ -52,13 +52,11 @@ public final class OrderBy extends AbstractQuery implements LimitRouter {
      *
      * @param limit The limit expression.
      * @return The Limit object that represents the LIMIT clause of the query.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, null);
     }
@@ -69,13 +67,11 @@ public final class OrderBy extends AbstractQuery implements LimitRouter {
      * @param limit  The limit expression.
      * @param offset The offset expression.
      * @return The Limit object that represents the LIMIT clause of the query.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit, Expression offset) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, offset);
     }

--- a/shared/src/main/java/com/couchbase/lite/Ordering.java
+++ b/shared/src/main/java/com/couchbase/lite/Ordering.java
@@ -17,6 +17,8 @@
 //
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -89,8 +91,13 @@ public abstract class Ordering {
      *
      * @param property the property name
      * @return the SortOrder object.
+     * @throws IllegalArgumentException when property is null.
      */
-    public static SortOrder property(String property) {
+    public static SortOrder property(@NonNull String property) {
+
+        if(property == null) {
+            throw new IllegalArgumentException("property is null");
+        }
         return expression(Expression.property(property));
     }
 
@@ -99,8 +106,13 @@ public abstract class Ordering {
      *
      * @param expression the expression object.
      * @return the SortOrder object.
+     * @throws IllegalArgumentException when expression is null.
      */
-    public static SortOrder expression(Expression expression) {
+    public static SortOrder expression(@NonNull Expression expression) {
+
+        if(expression == null) {
+            throw new IllegalArgumentException("expression is null");
+        }
         return new SortOrder(expression);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/Ordering.java
+++ b/shared/src/main/java/com/couchbase/lite/Ordering.java
@@ -91,12 +91,10 @@ public abstract class Ordering {
      *
      * @param property the property name
      * @return the SortOrder object.
-     * @throws IllegalArgumentException when property is null.
      */
     public static SortOrder property(@NonNull String property) {
-
-        if(property == null) {
-            throw new IllegalArgumentException("property is null");
+        if (property == null) {
+            throw new IllegalArgumentException("property is null.");
         }
         return expression(Expression.property(property));
     }
@@ -106,12 +104,10 @@ public abstract class Ordering {
      *
      * @param expression the expression object.
      * @return the SortOrder object.
-     * @throws IllegalArgumentException when expression is null.
      */
     public static SortOrder expression(@NonNull Expression expression) {
-
-        if(expression == null) {
-            throw new IllegalArgumentException("expression is null");
+        if (expression == null) {
+            throw new IllegalArgumentException("expression is null.");
         }
         return new SortOrder(expression);
     }

--- a/shared/src/main/java/com/couchbase/lite/Select.java
+++ b/shared/src/main/java/com/couchbase/lite/Select.java
@@ -54,13 +54,11 @@ public final class Select extends AbstractQuery implements FromRouter {
      *
      * @param dataSource the data source.
      * @return the From component.
-     * @throws IllegalArgumentException when dataSource is null.
      */
     @Override
     public From from(@NonNull DataSource dataSource) {
-
-        if(dataSource == null) {
-            throw new IllegalArgumentException("dataSource is null");
+        if (dataSource == null) {
+            throw new IllegalArgumentException("dataSource is null.");
         }
         return new From(this, dataSource);
     }

--- a/shared/src/main/java/com/couchbase/lite/Select.java
+++ b/shared/src/main/java/com/couchbase/lite/Select.java
@@ -18,6 +18,8 @@
 
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -52,9 +54,14 @@ public final class Select extends AbstractQuery implements FromRouter {
      *
      * @param dataSource the data source.
      * @return the From component.
+     * @throws IllegalArgumentException when dataSource is null.
      */
     @Override
-    public From from(DataSource dataSource) {
+    public From from(@NonNull DataSource dataSource) {
+
+        if(dataSource == null) {
+            throw new IllegalArgumentException("dataSource is null");
+        }
         return new From(this, dataSource);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/SelectResult.java
+++ b/shared/src/main/java/com/couchbase/lite/SelectResult.java
@@ -17,6 +17,8 @@
 //
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 /**
  * SelectResult represents a signle return value of the query statement.
  */
@@ -39,8 +41,13 @@ public class SelectResult {
          *
          * @param alias The data source alias name.
          * @return The SelectResult object with the data source alias name specified.
+         * @throws IllegalArgumentException when alias is null.
          */
-        public SelectResult from(String alias) {
+        public SelectResult from(@NonNull String alias) {
+
+            if(alias == null) {
+                throw new IllegalArgumentException("alias is null");
+            }
             this.expression = PropertyExpression.allFrom(alias);
             this.alias = alias;
             return this;
@@ -62,8 +69,13 @@ public class SelectResult {
          *
          * @param alias The alias name.
          * @return The SelectResult object with the alias name specified.
+         * @throws IllegalArgumentException when alias is null.
          */
-        public SelectResult as(String alias) {
+        public SelectResult as(@NonNull String alias) {
+
+            if(alias == null) {
+                throw new IllegalArgumentException("alias is null");
+            }
             this.alias = alias;
             return this;
         }
@@ -91,8 +103,13 @@ public class SelectResult {
      *
      * @param property The property name.
      * @return The SelectResult.As object that you can give the alias name to the returned value.
+     * @throws IllegalArgumentException when property is null.
      */
-    public static SelectResult.As property(String property) {
+    public static SelectResult.As property(@NonNull String property) {
+
+        if(property == null) {
+            throw new IllegalArgumentException("property is null");
+        }
         return new SelectResult.As(PropertyExpression.property(property));
     }
 
@@ -101,8 +118,13 @@ public class SelectResult {
      *
      * @param expression The expression.
      * @return The SelectResult.As object that you can give the alias name to the returned value.
+     * @throws IllegalArgumentException when expression is null.
      */
-    public static SelectResult.As expression(Expression expression) {
+    public static SelectResult.As expression(@NonNull Expression expression) {
+
+        if(expression == null) {
+            throw new IllegalArgumentException("expression is null");
+        }
         return new SelectResult.As(expression);
     }
 

--- a/shared/src/main/java/com/couchbase/lite/SelectResult.java
+++ b/shared/src/main/java/com/couchbase/lite/SelectResult.java
@@ -41,12 +41,10 @@ public class SelectResult {
          *
          * @param alias The data source alias name.
          * @return The SelectResult object with the data source alias name specified.
-         * @throws IllegalArgumentException when alias is null.
          */
         public SelectResult from(@NonNull String alias) {
-
-            if(alias == null) {
-                throw new IllegalArgumentException("alias is null");
+            if (alias == null) {
+                throw new IllegalArgumentException("alias is null.");
             }
             this.expression = PropertyExpression.allFrom(alias);
             this.alias = alias;
@@ -69,12 +67,10 @@ public class SelectResult {
          *
          * @param alias The alias name.
          * @return The SelectResult object with the alias name specified.
-         * @throws IllegalArgumentException when alias is null.
          */
         public SelectResult as(@NonNull String alias) {
-
-            if(alias == null) {
-                throw new IllegalArgumentException("alias is null");
+            if (alias == null) {
+                throw new IllegalArgumentException("alias is null.");
             }
             this.alias = alias;
             return this;
@@ -103,12 +99,10 @@ public class SelectResult {
      *
      * @param property The property name.
      * @return The SelectResult.As object that you can give the alias name to the returned value.
-     * @throws IllegalArgumentException when property is null.
      */
     public static SelectResult.As property(@NonNull String property) {
-
-        if(property == null) {
-            throw new IllegalArgumentException("property is null");
+        if (property == null) {
+            throw new IllegalArgumentException("property is null.");
         }
         return new SelectResult.As(PropertyExpression.property(property));
     }
@@ -118,12 +112,10 @@ public class SelectResult {
      *
      * @param expression The expression.
      * @return The SelectResult.As object that you can give the alias name to the returned value.
-     * @throws IllegalArgumentException when expression is null.
      */
     public static SelectResult.As expression(@NonNull Expression expression) {
-
-        if(expression == null) {
-            throw new IllegalArgumentException("expression is null");
+        if (expression == null) {
+            throw new IllegalArgumentException("expression is null.");
         }
         return new SelectResult.As(expression);
     }

--- a/shared/src/main/java/com/couchbase/lite/Where.java
+++ b/shared/src/main/java/com/couchbase/lite/Where.java
@@ -18,6 +18,8 @@
 
 package com.couchbase.lite;
 
+import android.support.annotation.NonNull;
+
 import java.util.Arrays;
 
 /**
@@ -42,9 +44,14 @@ public final class Where extends AbstractQuery implements GroupByRouter, OrderBy
      *
      * @param expressions The expression objects.
      * @return The GroupBy object.
+     * @throws IllegalArgumentException when expressions is null.
      */
     @Override
-    public GroupBy groupBy(Expression... expressions) {
+    public GroupBy groupBy(@NonNull Expression... expressions) {
+
+        if(expressions == null) {
+            throw new IllegalArgumentException("expressions is null");
+        }
         return new GroupBy(this, Arrays.asList(expressions));
     }
 
@@ -57,9 +64,14 @@ public final class Where extends AbstractQuery implements GroupByRouter, OrderBy
      *
      * @param orderings an array of the ORDER BY expressions.
      * @return the ORDER BY component.
+     * @throws IllegalArgumentException when orderings is null.
      */
     @Override
-    public OrderBy orderBy(Ordering... orderings) {
+    public OrderBy orderBy(@NonNull Ordering... orderings) {
+
+        if(orderings == null) {
+            throw new IllegalArgumentException("orderings is null");
+        }
         return new OrderBy(this, Arrays.asList(orderings));
     }
 
@@ -72,9 +84,14 @@ public final class Where extends AbstractQuery implements GroupByRouter, OrderBy
      *
      * @param limit The limit Expression object
      * @return The Limit object.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit) {
+    public Limit limit(@NonNull Expression limit) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, null);
     }
 
@@ -85,9 +102,14 @@ public final class Where extends AbstractQuery implements GroupByRouter, OrderBy
      * @param limit  The limit Expression object
      * @param offset The offset Expression object
      * @return The Limit object.
+     * @throws IllegalArgumentException when limit is null.
      */
     @Override
-    public Limit limit(Expression limit, Expression offset) {
+    public Limit limit(@NonNull Expression limit, Expression offset) {
+
+        if(limit == null) {
+            throw new IllegalArgumentException("limit is null");
+        }
         return new Limit(this, limit, offset);
     }
 }

--- a/shared/src/main/java/com/couchbase/lite/Where.java
+++ b/shared/src/main/java/com/couchbase/lite/Where.java
@@ -44,13 +44,11 @@ public final class Where extends AbstractQuery implements GroupByRouter, OrderBy
      *
      * @param expressions The expression objects.
      * @return The GroupBy object.
-     * @throws IllegalArgumentException when expressions is null.
      */
     @Override
     public GroupBy groupBy(@NonNull Expression... expressions) {
-
-        if(expressions == null) {
-            throw new IllegalArgumentException("expressions is null");
+        if (expressions == null) {
+            throw new IllegalArgumentException("expressions is null.");
         }
         return new GroupBy(this, Arrays.asList(expressions));
     }
@@ -64,13 +62,11 @@ public final class Where extends AbstractQuery implements GroupByRouter, OrderBy
      *
      * @param orderings an array of the ORDER BY expressions.
      * @return the ORDER BY component.
-     * @throws IllegalArgumentException when orderings is null.
      */
     @Override
     public OrderBy orderBy(@NonNull Ordering... orderings) {
-
-        if(orderings == null) {
-            throw new IllegalArgumentException("orderings is null");
+        if (orderings == null) {
+            throw new IllegalArgumentException("orderings is null.");
         }
         return new OrderBy(this, Arrays.asList(orderings));
     }
@@ -84,13 +80,11 @@ public final class Where extends AbstractQuery implements GroupByRouter, OrderBy
      *
      * @param limit The limit Expression object
      * @return The Limit object.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, null);
     }
@@ -102,13 +96,11 @@ public final class Where extends AbstractQuery implements GroupByRouter, OrderBy
      * @param limit  The limit Expression object
      * @param offset The offset Expression object
      * @return The Limit object.
-     * @throws IllegalArgumentException when limit is null.
      */
     @Override
     public Limit limit(@NonNull Expression limit, Expression offset) {
-
-        if(limit == null) {
-            throw new IllegalArgumentException("limit is null");
+        if (limit == null) {
+            throw new IllegalArgumentException("limit is null.");
         }
         return new Limit(this, limit, offset);
     }


### PR DESCRIPTION
Add null check with NonNull annotation in all the Query Clauses API calls.
Remove illegal argument usages in Query test.