### PR TITLE
Added warnings for when file logging is disabled

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/AbstractDatabase.java
+++ b/shared/src/main/java/com/couchbase/lite/AbstractDatabase.java
@@ -20,6 +20,7 @@ package com.couchbase.lite;
 import android.support.annotation.NonNull;
 
 import com.couchbase.lite.internal.support.Log;
+import com.couchbase.lite.internal.support.Run;
 import com.couchbase.lite.internal.utils.ExecutorUtils;
 import com.couchbase.lite.internal.utils.FileUtils;
 import com.couchbase.lite.internal.utils.JsonUtils;
@@ -135,8 +136,16 @@ abstract class AbstractDatabase {
         this.name = name;
         this.config = config.readonlyCopy();
         this.shellMode = false;
+        Run.once("CheckFileLogger", new Runnable() {
+            @Override
+            public void run() {
+                if(Database.log.getFile().getConfig() == null) {
+                    Log.w(TAG, "Database.log.getFile().getConfig() is null, meaning file logging is disabled.  Log files required for product support are not being generated.");
+                }
+            }
+        });
 
-        String tempdir = this.config.getTempDir();
+                String tempdir = this.config.getTempDir();
         if (tempdir != null)
             C4.setenv("TMPDIR", tempdir, 1);
         open();

--- a/shared/src/main/java/com/couchbase/lite/FileLogger.java
+++ b/shared/src/main/java/com/couchbase/lite/FileLogger.java
@@ -17,6 +17,7 @@
 //
 package com.couchbase.lite;
 
+import com.couchbase.lite.internal.support.Log;
 import com.couchbase.litecore.C4Constants;
 import com.couchbase.litecore.C4Log;
 
@@ -31,6 +32,8 @@ import java.util.Map;
  * a separate file.
  */
 public final class FileLogger implements Logger {
+    private static final String TAG = "FileLogger";
+
     private LogLevel _level = LogLevel.INFO;
     private LogFileConfiguration _config;
     private final HashMap<LogDomain, String> _domainObjects = new HashMap<>();
@@ -62,6 +65,10 @@ public final class FileLogger implements Logger {
      */
     public void setConfig(LogFileConfiguration config) {
         _config = config == null ? null : config.readOnlyCopy();
+        if(config == null) {
+            Log.w(TAG, "Database.log.getFile().getConfig() is now null, meaning file logging is disabled.  Log files required for product support are not being generated.");
+        }
+
         updateConfig();
     }
 

--- a/shared/src/main/java/com/couchbase/lite/internal/support/Run.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/support/Run.java
@@ -1,0 +1,57 @@
+//
+// RunOnce.java
+//
+// Copyright (c) 2019 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite.internal.support;
+
+import android.support.annotation.NonNull;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+ public final class Run {
+    private static final HashSet<String> Instances = new HashSet<>();
+    private static final ReentrantReadWriteLock InstancesLock = new ReentrantReadWriteLock();
+
+    @NonNull
+    public static void once(@NonNull String tag, @NonNull Runnable action) {
+        if(tag == null) {
+            throw new IllegalArgumentException("tag cannot be null");
+        }
+
+        if(action == null) {
+            throw new IllegalArgumentException("action cannot be null");
+        }
+
+        InstancesLock.readLock().lock();
+        try {
+            if(Instances.contains(tag)) {
+                return;
+            }
+        } finally {
+            InstancesLock.readLock().unlock();
+        }
+
+        InstancesLock.writeLock().lock();
+        try {
+            Instances.add(tag);
+            action.run();
+        } finally {
+            InstancesLock.writeLock().unlock();
+        }
+    }
+}

--- a/shared/src/main/java/com/couchbase/lite/internal/support/Run.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/support/Run.java
@@ -19,16 +19,13 @@ package com.couchbase.lite.internal.support;
 
 import android.support.annotation.NonNull;
 
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
  public final class Run {
     private static final HashSet<String> Instances = new HashSet<>();
-    private static final ReentrantReadWriteLock InstancesLock = new ReentrantReadWriteLock();
 
     @NonNull
-    public static void once(@NonNull String tag, @NonNull Runnable action) {
+    public static synchronized void once(@NonNull String tag, @NonNull Runnable action) {
         if(tag == null) {
             throw new IllegalArgumentException("tag cannot be null");
         }
@@ -37,21 +34,11 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
             throw new IllegalArgumentException("action cannot be null");
         }
 
-        InstancesLock.readLock().lock();
-        try {
-            if(Instances.contains(tag)) {
-                return;
-            }
-        } finally {
-            InstancesLock.readLock().unlock();
+        if(Instances.contains(tag)) {
+            return;
         }
 
-        InstancesLock.writeLock().lock();
-        try {
-            Instances.add(tag);
-            action.run();
-        } finally {
-            InstancesLock.writeLock().unlock();
-        }
+        Instances.add(tag);
+        action.run();
     }
 }


### PR DESCRIPTION
Note:  Unsure how to test this on Android without exposing a method that is meant only for debugging (.NET will compile out the "clear" method in release builds)