### PR TITLE
Generate code coverage report and submit to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,6 @@ before_script:
   - adb shell input keyevent 82 &
 script:
   - cd android && touch local.properties
-  - ./gradlew connectedAndroidTest --console=plain --info --full-stacktrace
+  - ./gradlew connectedAndroidTest --console=plain --info
+after_success:
+  - ./gradlew coveralls

--- a/android/CouchbaseLite/build.gradle
+++ b/android/CouchbaseLite/build.gradle
@@ -21,6 +21,7 @@
 apply plugin: 'com.android.library'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
+apply plugin: 'com.github.kt3k.coveralls'
 
 // NOTE: moved from project build.gradle to make CBL compilable as sub-module of application
 buildscript {
@@ -31,6 +32,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.1.0'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
     }
 }
 
@@ -194,6 +196,14 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     baseName = project.name
     classifier = 'javadoc'
     from javadoc.destinationDir
+}
+
+// ----------------------------------------------------------------
+// Coveralls
+// ----------------------------------------------------------------
+
+coveralls {
+    jacocoReportPath = "${buildDir}/reports/coverage/debug/report.xml"
 }
 
 // ----------------------------------------------------------------


### PR DESCRIPTION
* Updade build.gradle to use com.github.kt3k.coveralls plugin to submit the jacoco report to coveralls.
* In .travis.yml, run coveralls task after success.