### PR TITLE
fix: d(str, str, throwable) was logging v(str, str)

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -405,6 +405,41 @@ public class LogTest extends BaseTest {
         assertTrue(found);
     }
 
+    @Test
+    public void testWriteLogWithError() {
+        final File path = new File(
+                context.getCacheDir().getAbsolutePath(),
+                "testLogWithError"
+        );
+        final String logDirectory = emptyDirectory(path.getAbsolutePath());
+        LogFileConfiguration config = new LogFileConfiguration(logDirectory)
+                .setUsePlaintext(true);
+        testWithConfiguration(LogLevel.DEBUG, config, new Runnable() {
+            @Override
+            public void run() {
+                String uuid = UUID.randomUUID().toString();
+                String message = "test message";
+                CouchbaseLiteException error = new CouchbaseLiteException(uuid);
+                Log.v(LogDomain.DATABASE.toString(), message, error);
+                Log.i(LogDomain.DATABASE.toString(), message, error);
+                Log.w(LogDomain.DATABASE.toString(), message, error);
+                Log.e(LogDomain.DATABASE.toString(), message, error);
+                Log.d(LogDomain.DATABASE.toString(), message, error);
+                try {
+                    for (File log : path.listFiles()) {
+                        byte[] b = new byte[(int) log.length()];
+                        FileInputStream fileInputStream = new FileInputStream(log);
+                        fileInputStream.read(b);
+                        String contents = new String(b, StandardCharsets.US_ASCII);
+                        assertTrue(contents.contains(uuid));
+                    }
+                } catch(Exception e) {
+                    fail("Exception during test callback " + e.toString());
+                }
+            }
+        });
+    }
+
     //region Helper methods
     private void testWithConfiguration(LogLevel level, LogFileConfiguration config, Runnable r) {
         LogFileConfiguration old = Database.log.getFile().getConfig();

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -376,34 +376,6 @@ public class LogTest extends BaseTest {
             }
         });
     }
-    //endregion
-
-    @Test
-    public void testNonASCII() throws CouchbaseLiteException {
-        LogTestLogger customLogger = new LogTestLogger();
-        customLogger.setLevel(LogLevel.VERBOSE);
-        Database.log.setCustom(customLogger);
-        Database.log.getConsole().setDomains(EnumSet.of(LogDomain.ALL));
-        Database.log.getConsole().setLevel(LogLevel.VERBOSE);
-
-        String hebrew = "מזג האוויר נחמד היום"; // The weather is nice today.
-        MutableDocument doc = new MutableDocument();
-        doc.setString("hebrew", hebrew);
-        save(doc);
-
-        Query query = QueryBuilder.select(SelectResult.all()).from(DataSource.database(db));
-        assertEquals(query.execute().allResults().size(), 1);
-
-        String expectedHebrew = "[{\"hebrew\":\"" + hebrew + "\"}]";
-        boolean found = false;
-        for (String line : customLogger.getLines()) {
-            if (line.contains(expectedHebrew)) {
-                found = true;
-                break;
-            }
-        }
-        assertTrue(found);
-    }
 
     @Test
     public void testWriteLogWithError() {
@@ -438,6 +410,34 @@ public class LogTest extends BaseTest {
                 }
             }
         });
+    }
+    //endregion
+
+    @Test
+    public void testNonASCII() throws CouchbaseLiteException {
+        LogTestLogger customLogger = new LogTestLogger();
+        customLogger.setLevel(LogLevel.VERBOSE);
+        Database.log.setCustom(customLogger);
+        Database.log.getConsole().setDomains(EnumSet.of(LogDomain.ALL));
+        Database.log.getConsole().setLevel(LogLevel.VERBOSE);
+
+        String hebrew = "מזג האוויר נחמד היום"; // The weather is nice today.
+        MutableDocument doc = new MutableDocument();
+        doc.setString("hebrew", hebrew);
+        save(doc);
+
+        Query query = QueryBuilder.select(SelectResult.all()).from(DataSource.database(db));
+        assertEquals(query.execute().allResults().size(), 1);
+
+        String expectedHebrew = "[{\"hebrew\":\"" + hebrew + "\"}]";
+        boolean found = false;
+        for (String line : customLogger.getLines()) {
+            if (line.contains(expectedHebrew)) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(found);
     }
 
     //region Helper methods

--- a/shared/src/main/java/com/couchbase/lite/internal/support/Log.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/support/Log.java
@@ -371,7 +371,7 @@ public final class Log {
      * @param tr  An exception to log
      */
     public static void d(String tag, String msg, Throwable tr) {
-        v(tag, "Exception: %s", tr.toString());
+        d(tag, "Exception: %s", tr.toString());
     }
 
     /**


### PR DESCRIPTION
* when copied, mistakenly not changed the verbose to debug
* added unit test to validate the fix