### PR TITLE
fix:  log with args not printing for warning

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -376,6 +376,44 @@ public class LogTest extends BaseTest {
             }
         });
     }
+
+    @Test
+    public void testWriteLogWithErrorAndArgs() {
+        final File path = new File(
+                context.getCacheDir().getAbsolutePath(),
+                "testWriteLogWithErrorAndArgs"
+        );
+        final String logDirectory = emptyDirectory(path.getAbsolutePath());
+        LogFileConfiguration config = new LogFileConfiguration(logDirectory)
+                .setUsePlaintext(true);
+        testWithConfiguration(LogLevel.DEBUG, config, new Runnable() {
+            @Override
+            public void run() {
+                String uuid1 = UUID.randomUUID().toString();
+                String uuid2 = UUID.randomUUID().toString();
+                String message = "test message %s";
+                CouchbaseLiteException error = new CouchbaseLiteException(uuid1);
+                Log.v(LogDomain.DATABASE.toString(), message, error, uuid2);
+                Log.i(LogDomain.DATABASE.toString(), message, error, uuid2);
+                Log.w(LogDomain.DATABASE.toString(), message, error, uuid2);
+                Log.e(LogDomain.DATABASE.toString(), message, error, uuid2);
+                Log.d(LogDomain.DATABASE.toString(), message, error, uuid2);
+                try {
+                    for (File log : path.listFiles()) {
+                        byte[] b = new byte[(int) log.length()];
+                        FileInputStream fileInputStream = new FileInputStream(log);
+                        fileInputStream.read(b);
+                        String contents = new String(b, StandardCharsets.US_ASCII);
+                        assertTrue(contents.contains(uuid1));
+                        assertTrue(contents.contains(uuid2));
+                    }
+                } catch(Exception e) {
+                    fail("Exception during test callback " + e.toString());
+                }
+            }
+        });
+    }
+
     //endregion
 
     @Test

--- a/shared/src/main/java/com/couchbase/lite/internal/support/Log.java
+++ b/shared/src/main/java/com/couchbase/lite/internal/support/Log.java
@@ -288,6 +288,7 @@ public final class Log {
         } catch (Exception e) {
             msg = String.format(Locale.ENGLISH, "Unable to format log: %s (%s)", formatString, e.toString());
         }
+        sendToLoggers(LogLevel.WARNING, tag, msg);
     }
 
     /**


### PR DESCRIPTION
* warning was not printing anything to file. missed the sendToLoggers call.
* add test case for testing that.