### PR TITLE
test: Log File Configuration Constructor

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ArrayTest.java
@@ -19,9 +19,7 @@ package com.couchbase.lite;
 
 import com.couchbase.lite.internal.utils.DateUtils;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -44,9 +42,6 @@ public class ArrayTest extends BaseTest {
 
     static final String kArrayTestDate = "2007-06-30T08:34:09.001Z";
     static final String kArrayTestBlob = "i'm blob";
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private List<Object> arrayOfAllTypes() {
         List<Object> list = new ArrayList<>();

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/AuthenticatorTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/AuthenticatorTest.java
@@ -1,15 +1,10 @@
 package com.couchbase.lite;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.assertEquals;
 
 public class AuthenticatorTest extends BaseTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testBasicAuthenticatorInstance() throws CouchbaseLiteException {

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BaseTest.java
@@ -30,6 +30,8 @@ import com.couchbase.litecore.C4Constants;
 import org.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -60,6 +62,9 @@ public class BaseTest implements C4Constants, CBLError.Domain, CBLError.Code {
     private File dir = null;
     protected Database db = null;
     ExecutorService executor = null;
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     protected File getDir() {
         return dir;

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BlobTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/BlobTest.java
@@ -19,9 +19,7 @@ package com.couchbase.lite;
 
 import com.couchbase.lite.utils.IOUtils;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.IOException;
@@ -37,9 +35,6 @@ import static org.junit.Assert.assertTrue;
 public class BlobTest extends BaseTest {
     final static String kBlobTestBlob1 = "i'm blob";
     final static String kBlobTestBlob2 = "i'm blob2";
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testEquals() throws CouchbaseLiteException {

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -23,9 +23,7 @@ import com.couchbase.lite.internal.support.Log;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -44,9 +42,6 @@ import static org.junit.Assert.fail;
 
 public class DatabaseTest extends BaseTest {
     final static String kDatabaseTestBlob = "i'm blob";
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     //---------------------------------------------
     //  Helper methods

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DictionaryTest.java
@@ -19,9 +19,7 @@ package com.couchbase.lite;
 
 import com.couchbase.lite.internal.support.Log;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
@@ -39,9 +37,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 public class DictionaryTest extends BaseTest {
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
-
     @Test
     public void testCreateDictionary() throws CouchbaseLiteException {
         MutableDictionary address = new MutableDictionary();

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -448,6 +448,45 @@ public class LogTest extends BaseTest {
             }
         });
     }
+
+    @Test
+    public void testFileLogConfiguration() {
+        int rotateCount = 4;
+        long maxSize = 2048;
+        boolean usePlainText = true;
+        final File path1 = new File(
+                context.getCacheDir().getAbsolutePath(),
+                "testFileLogConfiguration"
+        );
+        LogFileConfiguration config = new LogFileConfiguration(path1.getAbsolutePath())
+                .setMaxRotateCount(rotateCount)
+                .setMaxSize(maxSize)
+                .setUsePlaintext(usePlainText);
+        assertEquals(config.getMaxRotateCount(), rotateCount);
+
+        // validate with LogFileConfiguration(String, config) constructor
+        final File path2 = new File(
+                context.getCacheDir().getAbsolutePath(),
+                "testFileLogConfigurationNew"
+        );
+        LogFileConfiguration newConfig = new LogFileConfiguration(path2.getAbsolutePath(), config);
+        assertEquals(newConfig.getMaxRotateCount(), rotateCount);
+        assertEquals(newConfig.getMaxSize(), maxSize);
+        assertEquals(newConfig.usesPlaintext(), usePlainText);
+        assertEquals(newConfig.getDirectory(), path2.getAbsolutePath());
+    }
+
+    @Test
+    public void testLogFileConfigWithEmptyArgs() {
+        LogFileConfiguration config;
+
+        thrown.expect(IllegalArgumentException.class);
+        config = new LogFileConfiguration((String)null);
+
+        thrown.expect(IllegalArgumentException.class);
+        config = new LogFileConfiguration((LogFileConfiguration) null);
+    }
+
     //endregion
 
     @Test
@@ -480,6 +519,7 @@ public class LogTest extends BaseTest {
     //region Helper methods
     private void testWithConfiguration(LogLevel level, LogFileConfiguration config, Runnable r) {
         LogFileConfiguration old = Database.log.getFile().getConfig();
+        EnumSet<LogDomain> domains = Database.log.getConsole().getDomains();
         Database.log.getFile().setConfig(config);
         Database.log.getFile().setLevel(level);
         try {
@@ -487,6 +527,8 @@ public class LogTest extends BaseTest {
         } finally {
             Database.log.getFile().setLevel(LogLevel.INFO);
             Database.log.getFile().setConfig(old);
+            Database.log.getConsole().setDomains(domains);
+            Database.log.getConsole().setLevel(LogLevel.INFO);
         }
     }
 

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -450,19 +450,30 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testFileLogConfiguration() {
+    public void testLogFileConfigurationConstructors() {
         int rotateCount = 4;
         long maxSize = 2048;
         boolean usePlainText = true;
+        LogFileConfiguration config;
+
+        thrown.expect(IllegalArgumentException.class);
+        config = new LogFileConfiguration((String)null);
+
+        thrown.expect(IllegalArgumentException.class);
+        config = new LogFileConfiguration((LogFileConfiguration) null);
+
         final File path1 = new File(
                 context.getCacheDir().getAbsolutePath(),
                 "testFileLogConfiguration"
         );
-        LogFileConfiguration config = new LogFileConfiguration(path1.getAbsolutePath())
+        config = new LogFileConfiguration(path1.getAbsolutePath())
                 .setMaxRotateCount(rotateCount)
                 .setMaxSize(maxSize)
                 .setUsePlaintext(usePlainText);
         assertEquals(config.getMaxRotateCount(), rotateCount);
+        assertEquals(config.getMaxSize(), maxSize);
+        assertEquals(config.usesPlaintext(), usePlainText);
+        assertEquals(config.getDirectory(), path1.getAbsolutePath());
 
         // validate with LogFileConfiguration(String, config) constructor
         final File path2 = new File(
@@ -477,14 +488,23 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testLogFileConfigWithEmptyArgs() {
-        LogFileConfiguration config;
+    public void testEditReadOnlyLogFileConfiguration() {
+        final File path = new File(
+                context.getCacheDir().getAbsolutePath(),
+                "testEditReadOnlyLogFileConfiguration"
+        );
+        final String logDirectory = emptyDirectory(path.getAbsolutePath());
+        LogFileConfiguration config = new LogFileConfiguration(logDirectory);
+        Database.log.getFile().setConfig(config);
 
-        thrown.expect(IllegalArgumentException.class);
-        config = new LogFileConfiguration((String)null);
+        thrown.expect(IllegalStateException.class);
+        Database.log.getFile().getConfig().setMaxSize(1024);
 
-        thrown.expect(IllegalArgumentException.class);
-        config = new LogFileConfiguration((LogFileConfiguration) null);
+        thrown.expect(IllegalStateException.class);
+        Database.log.getFile().getConfig().setMaxRotateCount(3);
+
+        thrown.expect(IllegalStateException.class);
+        Database.log.getFile().getConfig().setUsePlaintext(true);
     }
 
     //endregion

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -548,7 +548,7 @@ public class LogTest extends BaseTest {
             Database.log.getFile().setLevel(LogLevel.INFO);
             Database.log.getFile().setConfig(old);
             Database.log.getConsole().setDomains(domains);
-            Database.log.getConsole().setLevel(LogLevel.INFO);
+            Database.log.getConsole().setLevel(LogLevel.WARNING);
         }
     }
 

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/QueryTest.java
@@ -24,9 +24,7 @@ import android.os.Looper;
 import com.couchbase.lite.internal.support.Log;
 import com.couchbase.litecore.LiteCoreException;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Date;
 import java.util.ArrayList;
@@ -59,9 +57,6 @@ public class QueryTest extends BaseTest {
     private static SelectResult SR_EXPIRATION = SelectResult.expression(Meta.expiration);
     private static SelectResult SR_ALL = SelectResult.all();
     private static SelectResult SR_NUMBER1 = SelectResult.property("number1");
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private void runTestWithNumbers(List<Map<String, Object>> numbers, Object[][] cases)
             throws Exception {

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorOfflineTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ReplicatorOfflineTest.java
@@ -1,8 +1,6 @@
 package com.couchbase.lite;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -13,9 +11,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 public class ReplicatorOfflineTest extends BaseReplicatorTest {
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     @Test
     public void testEditReadOnlyConfiguration() throws Exception {

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ResultTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/ResultTest.java
@@ -19,9 +19,7 @@ package com.couchbase.lite;
 
 import com.couchbase.lite.internal.utils.DateUtils;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -55,9 +53,6 @@ public class ResultTest extends BaseTest {
     final static SelectResult SR_ARRAY = SelectResult.property("array");
     final static SelectResult SR_BLOB = SelectResult.property("blob");
     final static SelectResult SR_NO_KEY = SelectResult.property("non_existing_key");
-
-    @Rule
-    public ExpectedException thrown = ExpectedException.none();
 
     private static Query generateQuery(Database db, String docID) {
         Expression exDocID = Expression.string(docID);


### PR DESCRIPTION
* add check for log file configuration constructor
* refactored thrownException to BaseTest, and removed from other classes
* reset the console log after the tests are done.

link: #1457