### PR TITLE
refact: use temporaryFolder() rule

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -32,7 +32,7 @@ public class LogTest extends BaseTest {
     private Context context;
 
     @Rule
-    final public TemporaryFolder tempFolder = new TemporaryFolder();
+    public final TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception {

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -6,13 +6,16 @@ import android.support.test.InstrumentationRegistry;
 import com.couchbase.lite.internal.support.Log;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileReader;
 import java.io.FilenameFilter;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -27,6 +30,9 @@ import static junit.framework.TestCase.fail;
 
 public class LogTest extends BaseTest {
     private Context context;
+
+    @Rule
+    final private TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception {
@@ -74,11 +80,8 @@ public class LogTest extends BaseTest {
 
     //region File Logging Tests
     @Test
-    public void testFileLoggingLoggingLevels() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLoggingLoggingLevels"
-        );
+    public void testFileLoggingLoggingLevels() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory)
                 .setUsePlaintext(true)
@@ -129,11 +132,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testFileLoggingDefaultBinaryFormat() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLoggingDefaultBinaryFormat"
-        );
+    public void testFileLoggingDefaultBinaryFormat() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory);
 
@@ -168,11 +168,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testFileLoggingUsePlainText() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLoggingUsePlainText"
-        );
+    public void testFileLoggingUsePlainText() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory).setUsePlaintext(true);
 
@@ -213,11 +210,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testFileLoggingLogFilename() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLoggingLogFilename"
-        );
+    public void testFileLoggingLogFilename() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory);
 
@@ -238,11 +232,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testFileLoggingMaxSize() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLoggingMaxSize"
-        );
+    public void testFileLoggingMaxSize() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         final LogFileConfiguration config = new LogFileConfiguration(logDirectory)
                 .setUsePlaintext(true)
@@ -267,11 +258,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testFileLoggingDisableLogging() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLoggingDisableLogging"
-        );
+    public void testFileLoggingDisableLogging() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         final LogFileConfiguration config = new LogFileConfiguration(logDirectory)
                 .setUsePlaintext(true);
@@ -297,11 +285,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testFileLoggingReEnableLogging() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLoggingReEnableLogging"
-        );
+    public void testFileLoggingReEnableLogging() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory)
                 .setUsePlaintext(true);
@@ -346,11 +331,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testFileLoggingHeader() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLoggingHeader"
-        );
+    public void testFileLoggingHeader() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory)
                 .setUsePlaintext(true);
@@ -376,11 +358,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testWriteLogWithError() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testLogWithError"
-        );
+    public void testWriteLogWithError() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory)
                 .setUsePlaintext(true);
@@ -411,11 +390,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testWriteLogWithErrorAndArgs() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testWriteLogWithErrorAndArgs"
-        );
+    public void testWriteLogWithErrorAndArgs() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory)
                 .setUsePlaintext(true);
@@ -448,7 +424,7 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testLogFileConfigurationConstructors() {
+    public void testLogFileConfigurationConstructors() throws IOException {
         int rotateCount = 4;
         long maxSize = 2048;
         boolean usePlainText = true;
@@ -460,10 +436,7 @@ public class LogTest extends BaseTest {
         thrown.expect(IllegalArgumentException.class);
         config = new LogFileConfiguration((LogFileConfiguration) null);
 
-        final File path1 = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLogConfiguration"
-        );
+        final File path1 = tempFolder.newFolder();
         config = new LogFileConfiguration(path1.getAbsolutePath())
                 .setMaxRotateCount(rotateCount)
                 .setMaxSize(maxSize)
@@ -474,10 +447,7 @@ public class LogTest extends BaseTest {
         assertEquals(config.getDirectory(), path1.getAbsolutePath());
 
         // validate with LogFileConfiguration(String, config) constructor
-        final File path2 = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testFileLogConfigurationNew"
-        );
+        final File path2 = tempFolder.newFolder();
         LogFileConfiguration newConfig = new LogFileConfiguration(path2.getAbsolutePath(), config);
         assertEquals(newConfig.getMaxRotateCount(), rotateCount);
         assertEquals(newConfig.getMaxSize(), maxSize);
@@ -486,11 +456,8 @@ public class LogTest extends BaseTest {
     }
 
     @Test
-    public void testEditReadOnlyLogFileConfiguration() {
-        final File path = new File(
-                context.getCacheDir().getAbsolutePath(),
-                "testEditReadOnlyLogFileConfiguration"
-        );
+    public void testEditReadOnlyLogFileConfiguration() throws IOException {
+        final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory);
         Database.log.getFile().setConfig(config);

--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/LogTest.java
@@ -32,7 +32,7 @@ public class LogTest extends BaseTest {
     private Context context;
 
     @Rule
-    final private TemporaryFolder tempFolder = new TemporaryFolder();
+    final public TemporaryFolder tempFolder = new TemporaryFolder();
 
     @Before
     public void setUp() throws Exception {
@@ -460,16 +460,21 @@ public class LogTest extends BaseTest {
         final File path = tempFolder.newFolder();
         final String logDirectory = emptyDirectory(path.getAbsolutePath());
         LogFileConfiguration config = new LogFileConfiguration(logDirectory);
-        Database.log.getFile().setConfig(config);
+        testWithConfiguration(LogLevel.DEBUG, config, new Runnable() {
+            @Override
+            public void run() {
+                Database.log.getFile().setConfig(config);
 
-        thrown.expect(IllegalStateException.class);
-        Database.log.getFile().getConfig().setMaxSize(1024);
+                thrown.expect(IllegalStateException.class);
+                Database.log.getFile().getConfig().setMaxSize(1024);
 
-        thrown.expect(IllegalStateException.class);
-        Database.log.getFile().getConfig().setMaxRotateCount(3);
+                thrown.expect(IllegalStateException.class);
+                Database.log.getFile().getConfig().setMaxRotateCount(3);
 
-        thrown.expect(IllegalStateException.class);
-        Database.log.getFile().getConfig().setUsePlaintext(true);
+                thrown.expect(IllegalStateException.class);
+                Database.log.getFile().getConfig().setUsePlaintext(true);
+            }
+        });
     }
 
     //endregion


### PR DESCRIPTION
* instead of manual folders, use the TemporaryFolder() which is supposed to be removed after the test finishes.
* fix issue with setting the config in one test.