### PR TITLE
Fix reading from Blob stream not returning -1  when end of stream

### DIFF
--- a/shared/src/main/java/com/couchbase/lite/Blob.java
+++ b/shared/src/main/java/com/couchbase/lite/Blob.java
@@ -535,7 +535,7 @@ public final class Blob implements FLEncodable {
             try {
                 byte[] bytes = readStream.read(b.length);
                 System.arraycopy(bytes, 0, b, 0, bytes.length);
-                if (bytes.length >= 0)
+                if (bytes.length > 0)
                     return bytes.length;
                 else
                     return -1;
@@ -549,7 +549,7 @@ public final class Blob implements FLEncodable {
             try {
                 byte[] bytes = readStream.read(len);
                 System.arraycopy(bytes, 0, b, off, bytes.length);
-                if (bytes.length >= 0)
+                if (bytes.length > 0)
                     return bytes.length;
                 else
                     return -1;


### PR DESCRIPTION
* c4stream_read return zero not -1 when end of stream.
* Fixed BlobInputStream to return -1 when the number of bytes is zero.

#1900