### PR TITLE
Patches for #1899 and #1900

### DIFF
--- a/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
+++ b/android/CouchbaseLite/src/androidTest/java/com/couchbase/lite/DocumentTest.java
@@ -2082,7 +2082,7 @@ public class DocumentTest extends BaseTest {
             assertNotNull(is);
             byte[] buffer = new byte[10];
             int bytesRead = is.read(buffer);
-            assertEquals(0, bytesRead);
+            assertEquals(-1, bytesRead);
         } finally {
             try {
                 is.close();
@@ -2093,7 +2093,7 @@ public class DocumentTest extends BaseTest {
     }
 
     @Test
-    public void testBlobWithStream() throws IOException, CouchbaseLiteException {
+    public void testBlobWithEmptyStream() throws IOException, CouchbaseLiteException {
         MutableDocument doc = createMutableDocument("doc1");
         byte[] content = "".getBytes();
         InputStream stream = new ByteArrayInputStream(content);
@@ -2115,7 +2115,7 @@ public class DocumentTest extends BaseTest {
             assertNotNull(is);
             byte[] buffer = new byte[10];
             int bytesRead = is.read(buffer);
-            assertEquals(0, bytesRead);
+            assertEquals(-1, bytesRead);
         } finally {
             try {
                 is.close();

--- a/shared/src/main/java/com/couchbase/lite/Blob.java
+++ b/shared/src/main/java/com/couchbase/lite/Blob.java
@@ -519,41 +519,29 @@ public final class Blob implements FLEncodable {
         @Override
         public int read() throws IOException {
             try {
-                byte[] bytes = readStream.read(1);
-                if (bytes.length == 1)
-                    return bytes[0];
-                else
-                    // EOF
-                    return -1;
-            } catch (LiteCoreException e) {
+                final byte[] bytes = readStream.read(1);
+                return (bytes.length <= 0) ? -1 : bytes[0];
+            }
+            catch (LiteCoreException e) {
                 throw new IOException(e);
             }
         }
 
         @Override
         public int read(byte[] b) throws IOException {
-            try {
-                byte[] bytes = readStream.read(b.length);
-                System.arraycopy(bytes, 0, b, 0, bytes.length);
-                if (bytes.length > 0)
-                    return bytes.length;
-                else
-                    return -1;
-            } catch (LiteCoreException e) {
-                throw new IOException(e);
-            }
+            return read(b, 0, b.length);
         }
 
         @Override
         public int read(byte[] b, int off, int len) throws IOException {
+            if (b.length <= 0) { return 0; }
             try {
-                byte[] bytes = readStream.read(len);
+                final byte[] bytes = readStream.read(len);
+                if (bytes.length <= 0) { return -1; }
                 System.arraycopy(bytes, 0, b, off, bytes.length);
-                if (bytes.length > 0)
-                    return bytes.length;
-                else
-                    return -1;
-            } catch (LiteCoreException e) {
+                return bytes.length;
+            }
+            catch (LiteCoreException e) {
                 throw new IOException(e);
             }
         }


### PR DESCRIPTION
Fix tests to expect -1 on BlobStream EOF
BlobStream.read return 0 when called with 0-length buffer
Update core submodule