### PR TITLE
Support x86_64 and update build tool

### DIFF
--- a/android/CouchbaseLite/build.gradle
+++ b/android/CouchbaseLite/build.gradle
@@ -74,7 +74,7 @@ android {
         project.archivesBaseName = "couchbase-lite-android-${versionName}"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         ndk {
-            abiFilters 'x86', 'armeabi-v7a', 'arm64-v8a'
+            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
         }
         externalNativeBuild {
             cmake {

--- a/android/CouchbaseLite/build.gradle
+++ b/android/CouchbaseLite/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.0'
+        classpath 'com.android.tools.build:gradle:3.4.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7.3'
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
     }
@@ -64,7 +64,7 @@ def getGitHash = { ->
  */
 android {
     compileSdkVersion 27
-    buildToolsVersion '27.0.3'
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion 19
@@ -78,6 +78,7 @@ android {
         }
         externalNativeBuild {
             cmake {
+                version '3.6.0'
                 arguments '-DANDROID_STL=c++_static', "-DANDROID_TOOLCHAIN=clang", '-DANDROID_PLATFORM=android-19', '-DJNI=TRUE'
                 cppFlags "-std=c++11 -frtti -fexceptions -fPIC"
                 // explicitly build libs
@@ -276,32 +277,34 @@ def pomConfig = {
     }
 }
 
-publishing {
-    publications {
-        mavenJava(MavenPublication) {
-            groupId group
-            artifactId 'couchbase-lite-android'
-            version this.version
+project.afterEvaluate {
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                groupId group
+                artifactId 'couchbase-lite-android'
+                version this.version
 
-            artifact bundleRelease
-            artifact sourcesJar
-            artifact javadocJar
+                artifact bundleReleaseAar
+                artifact sourcesJar
+                artifact javadocJar
 
-            pom.withXml {
-                def root = asNode()
-                // Workaround for description:
-                root.appendNode('description', 'Couchbase Lite is an embedded lightweight, document-oriented (NoSQL), syncable database engine.')
-                root.children().last() + pomConfig
+                pom.withXml {
+                    def root = asNode()
+                    // Workaround for description:
+                    root.appendNode('description', 'Couchbase Lite is an embedded lightweight, document-oriented (NoSQL), syncable database engine.')
+                    root.children().last() + pomConfig
 
-                // maven-publish workaround to include dependencies
-                def dependenciesNode = asNode().appendNode('dependencies')
+                    // maven-publish workaround to include dependencies
+                    def dependenciesNode = asNode().appendNode('dependencies')
 
-                //Iterate over the compile dependencies (we don't want the test ones), adding a <dependency> node for each
-                configurations.implementation.allDependencies.each {
-                    def dependencyNode = dependenciesNode.appendNode('dependency')
-                    dependencyNode.appendNode('groupId', it.group)
-                    dependencyNode.appendNode('artifactId', it.name)
-                    dependencyNode.appendNode('version', it.version)
+                    //Iterate over the compile dependencies (we don't want the test ones), adding a <dependency> node for each
+                    configurations.implementation.allDependencies.each {
+                        def dependencyNode = dependenciesNode.appendNode('dependency')
+                        dependencyNode.appendNode('groupId', it.group)
+                        dependencyNode.appendNode('artifactId', it.name)
+                        dependencyNode.appendNode('version', it.version)
+                    }
                 }
             }
         }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-bin.zip


### PR DESCRIPTION
* Added support for x86_64.
* Updated build tool version to 28.0.3.
* Update gradle version to 5.1.1 and gradle build version to 3.4.1.
* Specified CMAKE version as 3.6.0.