### PR TITLE
Clean up JNI and improve freeing native memory (CBL-130)

### DIFF
--- a/lib/src/androidTest/java/com/couchbase/lite/ConcurrencyTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/ConcurrencyTest.java
@@ -25,7 +25,6 @@ import java.util.Locale;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.Test;
 

--- a/lib/src/androidTest/java/com/couchbase/lite/EncodingTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/EncodingTest.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import org.junit.Test;
 
 import com.couchbase.lite.internal.fleece.AllocSlice;
-import com.couchbase.lite.internal.fleece.Encoder;
+import com.couchbase.lite.internal.fleece.FLEncoder;
 import com.couchbase.lite.internal.fleece.FLValue;
 
 import static org.junit.Assert.assertEquals;
@@ -36,7 +36,7 @@ public class EncodingTest extends BaseTest {
 
     // https://github.com/couchbase/couchbase-lite-android/issues/1453
     @Test
-    public void testFLEncode() {
+    public void testFLEncode() throws Exception {
         testRoundTrip(42L);
         testRoundTrip(Long.MIN_VALUE);
         testRoundTrip("Fleece");
@@ -50,7 +50,7 @@ public class EncodingTest extends BaseTest {
     }
 
     @Test
-    public void testFLEncodeUTF8() {
+    public void testFLEncodeUTF8() throws Exception {
         testRoundTrip("Goodbye cruel world"); // one byte utf-8 chars
         testRoundTrip("Goodbye cruel £ world"); // a two byte utf-8 chars
         testRoundTrip("Goodbye cruel ᘺ world"); // a three byte utf-8 char
@@ -128,14 +128,14 @@ public class EncodingTest extends BaseTest {
             null);
     }
 
-    private void testRoundTrip(Object item) { testRoundTrip(item, item); }
+    private void testRoundTrip(Object item) throws Exception { testRoundTrip(item, item); }
 
-    private void testRoundTrip(Object item, Object expected) {
-        Encoder encoder = new Encoder();
-        assertNotNull(encoder);
+    private void testRoundTrip(Object item, Object expected) throws Exception {
+        final FLEncoder encoder = new FLEncoder();
+        AllocSlice slice = null;
         try {
-            assertTrue(encoder.writeObject(item));
-            AllocSlice slice = encoder.finish();
+            assertTrue(encoder.writeValue(item));
+            slice = encoder.finish2();
             assertNotNull(slice);
             FLValue flValue = FLValue.fromData(slice);
             assertNotNull(flValue);
@@ -143,7 +143,8 @@ public class EncodingTest extends BaseTest {
             assertEquals(expected, obj);
         }
         finally {
-            encoder.release();
+            if (slice != null) slice.free();
+            encoder.free();
         }
     }
 

--- a/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4BaseTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4BaseTest.java
@@ -138,24 +138,29 @@ public class C4BaseTest {
 
     private byte[] createFleeceBody(Map<String, Object> body) throws LiteCoreException {
         FLEncoder enc = new FLEncoder();
-        enc.beginDict(body != null ? body.size() : 0);
-        for (String key : body.keySet()) {
-            enc.writeKey(key);
-            enc.writeValue(body.get(key));
-        }
-        enc.endDict();
-        return enc.finish();
+        try {
+            enc.beginDict(body != null ? body.size() : 0);
+            for (String key : body.keySet()) {
+                enc.writeKey(key);
+                enc.writeValue(body.get(key));
+            }
+            enc.endDict();
+            return enc.finish();
+        } finally { enc.free(); }
     }
 
     protected byte[] json2fleece(String json) throws LiteCoreException {
         boolean commit = false;
         db.beginTransaction();
+        FLSliceResult body = null;
         try {
-            byte[] bytes = db.encodeJSON(json5(json).getBytes()).getBuf();
+            body = db.encodeJSON(json5(json).getBytes());
+            byte[] bytes = body.getBuf();
             commit = true;
             return bytes;
         }
         finally {
+            if (body != null) body.free();;
             db.endTransaction(commit);
         }
     }
@@ -176,9 +181,7 @@ public class C4BaseTest {
             assertNotNull(output);
             Assert.assertArrayEquals(input, output);
         }
-        finally {
-            enc.free();
-        }
+        finally { enc.free(); }
     }
 
     @After

--- a/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4BaseTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4BaseTest.java
@@ -160,7 +160,7 @@ public class C4BaseTest {
             return bytes;
         }
         finally {
-            if (body != null) body.free();;
+            if (body != null) body.free();
             db.endTransaction(commit);
         }
     }

--- a/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4MutableFleeceTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4MutableFleeceTest.java
@@ -33,7 +33,7 @@ import org.junit.Test;
 
 import com.couchbase.lite.LiteCoreException;
 import com.couchbase.lite.internal.fleece.AllocSlice;
-import com.couchbase.lite.internal.fleece.Encoder;
+import com.couchbase.lite.internal.fleece.FLEncoder;
 import com.couchbase.lite.internal.fleece.FLValue;
 import com.couchbase.lite.internal.fleece.FleeceDict;
 import com.couchbase.lite.internal.fleece.FleeceDocument;
@@ -50,27 +50,38 @@ import static org.junit.Assert.assertTrue;
 
 public class C4MutableFleeceTest extends C4BaseTest {
 
+    private MValue.Delegate delegate;
+
     @Before
     public void setUp() throws Exception {
         super.setUp();
+        delegate = MValue.getRegisteredDelegate();
         MValue.registerDelegate(new MValueDelegate());
     }
 
     @After
     public void tearDown() throws Exception {
+        if (delegate != null)
+            MValue.registerDelegate(delegate);
         super.tearDown();
     }
 
     static AllocSlice encode(Object obj) throws LiteCoreException {
-        Encoder enc = new Encoder();
-        enc.writeObject(obj);
-        return enc.finish();
+        FLEncoder enc = new FLEncoder();
+        try {
+            enc.writeValue(obj);
+            return enc.finish2();
+        }
+        finally { enc.free(); }
     }
 
     static AllocSlice encode(MRoot root) throws LiteCoreException {
-        Encoder enc = new Encoder();
-        root.encodeTo(enc);
-        return enc.finish();
+        FLEncoder enc = new FLEncoder();
+        try {
+            root.encodeTo(enc);
+            return enc.finish2();
+        }
+        finally { enc.free(); }
     }
 
     static List<String> sortedKeys(Map<String, Object> dict) {
@@ -93,9 +104,14 @@ public class C4MutableFleeceTest extends C4BaseTest {
     }
 
     static String fleece2JSON(AllocSlice fleece) {
-        FLValue v = FLValue.fromData(fleece);
-        if (v == null) { return "INVALID_FLEECE"; }
-        return v.toJSON5();
+        try {
+            FLValue v = FLValue.fromData(fleece);
+            if (v == null) { return "INVALID_FLEECE"; }
+            return v.toJSON5();
+        }
+        finally {
+            if (fleece != null) fleece.free();
+        }
     }
 
     // TEST_CASE("MValue", "[Mutable]")
@@ -116,54 +132,60 @@ public class C4MutableFleeceTest extends C4BaseTest {
         subMap.put("melt", 32);
         subMap.put("boil", 212);
         map.put("dict", subMap);
+
         AllocSlice data = encode(map);
 
-        MRoot root = new MRoot(data);
-        assertFalse(root.isMutated());
-        Object obj = root.asNative();
-        assertNotNull(obj);
-        assertTrue(obj instanceof Map);
-        Map<String, Object> dict = (Map<String, Object>) obj;
-        assertNotNull(dict);
-        assertEquals(3, dict.size());
-        assertTrue(dict.containsKey("greeting"));
-        assertFalse(dict.containsKey("x"));
-        assertEquals(Arrays.asList("array", "dict", "greeting"), sortedKeys(dict));
-        assertEquals("hi", dict.get("greeting"));
-        assertNull(dict.get("x"));
+        try {
+            MRoot root = new MRoot(data);
+            assertFalse(root.isMutated());
+            Object obj = root.asNative();
+            assertNotNull(obj);
+            assertTrue(obj instanceof Map);
+            Map<String, Object> dict = (Map<String, Object>) obj;
+            assertNotNull(dict);
+            assertEquals(3, dict.size());
+            assertTrue(dict.containsKey("greeting"));
+            assertFalse(dict.containsKey("x"));
+            assertEquals(Arrays.asList("array", "dict", "greeting"), sortedKeys(dict));
+            assertEquals("hi", dict.get("greeting"));
+            assertNull(dict.get("x"));
 
-        obj = dict.get("dict");
-        assertNotNull(obj);
-        assertTrue(obj instanceof Map);
-        Map<String, Object> nested = (Map<String, Object>) obj;
-        assertEquals(sortedKeys(nested), Arrays.asList("boil", "melt"));
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("melt", 32L);
-        expected.put("boil", 212L);
-        assertEquals(expected, nested);
-        assertEquals(32L, nested.get("melt"));
-        assertEquals(212L, nested.get("boil"));
-        assertNull(nested.get("freeze"));
-        assertFalse(root.isMutated());
+            obj = dict.get("dict");
+            assertNotNull(obj);
+            assertTrue(obj instanceof Map);
+            Map<String, Object> nested = (Map<String, Object>) obj;
+            assertEquals(sortedKeys(nested), Arrays.asList("boil", "melt"));
+            Map<String, Object> expected = new HashMap<>();
+            expected.put("melt", 32L);
+            expected.put("boil", 212L);
+            assertEquals(expected, nested);
+            assertEquals(32L, nested.get("melt"));
+            assertEquals(212L, nested.get("boil"));
+            assertNull(nested.get("freeze"));
+            assertFalse(root.isMutated());
 
-        verifyDictIterator(dict);
+            verifyDictIterator(dict);
 
-        nested.put("freeze", Arrays.asList(32L, "Fahrenheit"));
-        assertTrue(root.isMutated());
-        assertEquals(32L, nested.remove("melt"));
-        expected.clear();
-        expected.put("freeze", Arrays.asList(32L, "Fahrenheit"));
-        expected.put("boil", 212L);
-        assertEquals(expected, nested);
+            nested.put("freeze", Arrays.asList(32L, "Fahrenheit"));
+            assertTrue(root.isMutated());
+            assertEquals(32L, nested.remove("melt"));
+            expected.clear();
+            expected.put("freeze", Arrays.asList(32L, "Fahrenheit"));
+            expected.put("boil", 212L);
+            assertEquals(expected, nested);
 
-        verifyDictIterator(dict);
+            verifyDictIterator(dict);
 
-        assertEquals(
-            "{array:[\"boo\",false],dict:{boil:212,freeze:[32,\"Fahrenheit\"]},greeting:\"hi\"}",
-            fleece2JSON(encode(dict)));
-        assertEquals(
-            "{array:[\"boo\",false],dict:{boil:212,freeze:[32,\"Fahrenheit\"]},greeting:\"hi\"}",
-            fleece2JSON(encode(root)));
+            assertEquals(
+                    "{array:[\"boo\",false],dict:{boil:212,freeze:[32,\"Fahrenheit\"]},greeting:\"hi\"}",
+                    fleece2JSON(encode(dict)));
+            assertEquals(
+                    "{array:[\"boo\",false],dict:{boil:212,freeze:[32,\"Fahrenheit\"]},greeting:\"hi\"}",
+                    fleece2JSON(encode(root)));
+        }
+        finally {
+            if (data != null) data.free();
+        }
     }
 
     // TEST_CASE("MArray", "[Mutable]")
@@ -172,46 +194,51 @@ public class C4MutableFleeceTest extends C4BaseTest {
         List<Object> list = Arrays.asList("hi", Arrays.asList("boo", false), 42);
         AllocSlice data = encode(list);
 
-        MRoot root = new MRoot(data);
-        assertFalse(root.isMutated());
-        Object obj = root.asNative();
-        assertNotNull(obj);
-        assertTrue(obj instanceof List);
-        List<Object> array = (List<Object>) obj;
-        assertNotNull(array);
-        assertEquals(3, array.size());
-        assertEquals("hi", array.get(0));
-        assertEquals(42L, array.get(2));
-        assertNotNull(array.get(1));
-        obj = array.get(1);
-        assertTrue(obj instanceof List);
-        assertEquals(Arrays.asList("boo", false), (List<Object>) obj);
-        array.set(0, Arrays.asList(3.14, 2.17));
-        array.add(2, "NEW");
-        assertEquals(Arrays.asList(3.14, 2.17), array.get(0));
-        assertEquals(Arrays.asList("boo", false), array.get(1));
-        assertEquals("NEW", array.get(2));
-        assertEquals(42L, array.get(3));
-        assertEquals(4, array.size());
+        try {
+            MRoot root = new MRoot(data);
+            assertFalse(root.isMutated());
+            Object obj = root.asNative();
+            assertNotNull(obj);
+            assertTrue(obj instanceof List);
+            List<Object> array = (List<Object>) obj;
+            assertNotNull(array);
+            assertEquals(3, array.size());
+            assertEquals("hi", array.get(0));
+            assertEquals(42L, array.get(2));
+            assertNotNull(array.get(1));
+            obj = array.get(1);
+            assertTrue(obj instanceof List);
+            assertEquals(Arrays.asList("boo", false), (List<Object>) obj);
+            array.set(0, Arrays.asList(3.14, 2.17));
+            array.add(2, "NEW");
+            assertEquals(Arrays.asList(3.14, 2.17), array.get(0));
+            assertEquals(Arrays.asList("boo", false), array.get(1));
+            assertEquals("NEW", array.get(2));
+            assertEquals(42L, array.get(3));
+            assertEquals(4, array.size());
 
-        List<Object> expected = new ArrayList<>();
-        expected.add(Arrays.asList(3.14, 2.17));
-        expected.add(Arrays.asList("boo", false));
-        expected.add("NEW");
-        expected.add(42L);
-        assertEquals(expected, array);
+            List<Object> expected = new ArrayList<>();
+            expected.add(Arrays.asList(3.14, 2.17));
+            expected.add(Arrays.asList("boo", false));
+            expected.add("NEW");
+            expected.add(42L);
+            assertEquals(expected, array);
 
-        obj = (List<Object>) array.get(1);
-        assertTrue(obj instanceof List);
-        List<Object> nested = (List<Object>) obj;
-        nested.set(1, true);
+            obj = (List<Object>) array.get(1);
+            assertTrue(obj instanceof List);
+            List<Object> nested = (List<Object>) obj;
+            nested.set(1, true);
 
-        assertEquals(
-            "[[3.14,2.17],[\"boo\",true],\"NEW\",42]",
-            fleece2JSON(encode(array)));
-        assertEquals(
-            "[[3.14,2.17],[\"boo\",true],\"NEW\",42]",
-            fleece2JSON(encode(root)));
+            assertEquals(
+                    "[[3.14,2.17],[\"boo\",true],\"NEW\",42]",
+                    fleece2JSON(encode(array)));
+            assertEquals(
+                    "[[3.14,2.17],[\"boo\",true],\"NEW\",42]",
+                    fleece2JSON(encode(root)));
+        }
+        finally {
+            if (data != null) data.free();
+        }
     }
 
     // TEST_CASE("MArray iteration", "[Mutable]")
@@ -220,13 +247,17 @@ public class C4MutableFleeceTest extends C4BaseTest {
         List<Object> orig = new ArrayList<>();
         for (int i = 0; i < 100; i++) { orig.add(String.format(Locale.ENGLISH, "This is item number %d", i)); }
         AllocSlice data = encode(orig);
-        MRoot root = new MRoot(data);
-        List<Object> array = (List<Object>) root.asNative();
-
-        int i = 0;
-        for (Object o : array) {
-            assertEquals(orig.get(i), o);
-            i++;
+        try {
+            MRoot root = new MRoot(data);
+            List<Object> array = (List<Object>) root.asNative();
+            int i = 0;
+            for (Object o : array) {
+                assertEquals(orig.get(i), o);
+                i++;
+            }
+        }
+        finally {
+            if (data != null) data.free();
         }
     }
 
@@ -243,47 +274,52 @@ public class C4MutableFleeceTest extends C4BaseTest {
         map.put("dict", subMap);
 
         AllocSlice data = encode(map);
-        Object obj = FleeceDocument.getObject(data, true);
-        assertNotNull(obj);
-        assertTrue(obj instanceof Map);
-        Map<String, Object> dict = (Map<String, Object>) obj;
-        assertFalse(((FleeceDict) dict).isMutated());
-        assertEquals(Arrays.asList("array", "dict", "greeting"), sortedKeys(dict));
-        assertEquals("hi", dict.get("greeting"));
-        assertNull(dict.get("x"));
-        verifyDictIterator(dict);
+        try {
+            Object obj = FleeceDocument.getObject(data, true);
+            assertNotNull(obj);
+            assertTrue(obj instanceof Map);
+            Map<String, Object> dict = (Map<String, Object>) obj;
+            assertFalse(((FleeceDict) dict).isMutated());
+            assertEquals(Arrays.asList("array", "dict", "greeting"), sortedKeys(dict));
+            assertEquals("hi", dict.get("greeting"));
+            assertNull(dict.get("x"));
+            verifyDictIterator(dict);
 
-        obj = dict.get("dict");
-        assertNotNull(obj);
-        assertTrue(obj instanceof Map);
-        Map<String, Object> nested = (Map<String, Object>) obj;
-        assertEquals(sortedKeys(nested), Arrays.asList("boil", "melt"));
-        Map<String, Object> expected = new HashMap<>();
-        expected.put("melt", 32L);
-        expected.put("boil", 212L);
-        assertEquals(expected, nested);
-        assertEquals(32L, nested.get("melt"));
-        assertEquals(212L, nested.get("boil"));
-        assertNull(nested.get("freeze"));
-        verifyDictIterator(nested);
-        assertFalse(((FleeceDict) nested).isMutated());
-        assertFalse(((FleeceDict) dict).isMutated());
+            obj = dict.get("dict");
+            assertNotNull(obj);
+            assertTrue(obj instanceof Map);
+            Map<String, Object> nested = (Map<String, Object>) obj;
+            assertEquals(sortedKeys(nested), Arrays.asList("boil", "melt"));
+            Map<String, Object> expected = new HashMap<>();
+            expected.put("melt", 32L);
+            expected.put("boil", 212L);
+            assertEquals(expected, nested);
+            assertEquals(32L, nested.get("melt"));
+            assertEquals(212L, nested.get("boil"));
+            assertNull(nested.get("freeze"));
+            verifyDictIterator(nested);
+            assertFalse(((FleeceDict) nested).isMutated());
+            assertFalse(((FleeceDict) dict).isMutated());
 
-        nested.put("freeze", Arrays.asList(32L, "Fahrenheit"));
-        assertTrue(((FleeceDict) nested).isMutated());
-        assertTrue(((FleeceDict) dict).isMutated());
-        assertEquals(32L, nested.remove("melt"));
-        expected.clear();
-        expected.put("freeze", Arrays.asList(32L, "Fahrenheit"));
-        expected.put("boil", 212L);
-        assertEquals(expected, nested);
+            nested.put("freeze", Arrays.asList(32L, "Fahrenheit"));
+            assertTrue(((FleeceDict) nested).isMutated());
+            assertTrue(((FleeceDict) dict).isMutated());
+            assertEquals(32L, nested.remove("melt"));
+            expected.clear();
+            expected.put("freeze", Arrays.asList(32L, "Fahrenheit"));
+            expected.put("boil", 212L);
+            assertEquals(expected, nested);
 
-        verifyDictIterator(nested);
-        verifyDictIterator(dict);
+            verifyDictIterator(nested);
+            verifyDictIterator(dict);
 
-        assertEquals(
-            "{array:[\"boo\",false],dict:{boil:212,freeze:[32,\"Fahrenheit\"]},greeting:\"hi\"}",
-            fleece2JSON(encode(dict)));
+            assertEquals(
+                    "{array:[\"boo\",false],dict:{boil:212,freeze:[32,\"Fahrenheit\"]},greeting:\"hi\"}",
+                    fleece2JSON(encode(dict)));
+        }
+        finally {
+            if (data != null) data.free();
+        }
     }
 
     // TEST_CASE("Adding mutable collections", "[Mutable]")
@@ -299,26 +335,30 @@ public class C4MutableFleeceTest extends C4BaseTest {
         map.put("dict", subMap);
 
         AllocSlice data = encode(map);
+        try {
+            MRoot root = new MRoot(data);
+            assertFalse(root.isMutated());
+            Object obj = root.asNative();
+            assertNotNull(obj);
+            assertTrue(obj instanceof Map);
+            Map<String, Object> dict = (Map<String, Object>) obj;
 
-        MRoot root = new MRoot(data);
-        assertFalse(root.isMutated());
-        Object obj = root.asNative();
-        assertNotNull(obj);
-        assertTrue(obj instanceof Map);
-        Map<String, Object> dict = (Map<String, Object>) obj;
+            obj = dict.get("array");
+            assertTrue(obj instanceof List);
+            List<Object> array = (List<Object>) obj;
+            dict.put("new", array);
+            array.add(true);
 
-        obj = dict.get("array");
-        assertTrue(obj instanceof List);
-        List<Object> array = (List<Object>) obj;
-        dict.put("new", array);
-        array.add(true);
-
-        assertEquals(
-            "{array:[\"boo\",false,true],dict:{boil:212,melt:32},greeting:\"hi\",new:[\"boo\",false,true]}",
-            fleece2JSON(encode(root)));
-        assertEquals(
-            "{array:[\"boo\",false,true],dict:{boil:212,melt:32},greeting:\"hi\",new:[\"boo\",false,true]}",
-            fleece2JSON(root.encode()));
+            assertEquals(
+                    "{array:[\"boo\",false,true],dict:{boil:212,melt:32},greeting:\"hi\",new:[\"boo\",false,true]}",
+                    fleece2JSON(encode(root)));
+            assertEquals(
+                    "{array:[\"boo\",false,true],dict:{boil:212,melt:32},greeting:\"hi\",new:[\"boo\",false,true]}",
+                    fleece2JSON(root.encode()));
+        }
+        finally {
+            if (data != null) data.free();
+        }
     }
 
     @Test
@@ -330,50 +370,60 @@ public class C4MutableFleeceTest extends C4BaseTest {
         map.put("greeting", "hi");
         map.put("array", Arrays.asList("boo", false));
         map.put("dict", subMap);
+
         AllocSlice data = encode(map);
+        try {
+            MRoot root = new MRoot(data);
+            assertFalse(root.isMutated());
+            Object obj = root.asNative();
+            assertNotNull(obj);
+            assertTrue(obj instanceof Map);
+            Map<String, Object> dict = (Map<String, Object>) obj;
+            assertEquals("hi", dict.get("greeting"));
+            assertEquals(Arrays.asList("boo", false), dict.get("array"));
+            assertEquals(subMap, dict.get("dict"));
 
-        MRoot root = new MRoot(data);
-        assertFalse(root.isMutated());
-        Object obj = root.asNative();
-        assertNotNull(obj);
-        assertTrue(obj instanceof Map);
-        Map<String, Object> dict = (Map<String, Object>) obj;
-        assertEquals("hi", dict.get("greeting"));
-        assertEquals(Arrays.asList("boo", false), dict.get("array"));
-        assertEquals(subMap, dict.get("dict"));
+            assertEquals("{array:[\"boo\",false],dict:{boil:212,melt:32},greeting:\"hi\"}", fleece2JSON(root.encode()));
 
-        assertEquals("{array:[\"boo\",false],dict:{boil:212,melt:32},greeting:\"hi\"}", fleece2JSON(root.encode()));
-
-        List<Object> array = (List<Object>) dict.get("array");
-        dict.put("new", array);
-        array.add(true);
-        assertEquals(
-            "{array:[\"boo\",false,true],dict:{boil:212,melt:32},greeting:\"hi\",new:[\"boo\",false,true]}",
-            fleece2JSON(root.encode()));
+            List<Object> array = (List<Object>) dict.get("array");
+            dict.put("new", array);
+            array.add(true);
+            assertEquals(
+                    "{array:[\"boo\",false,true],dict:{boil:212,melt:32},greeting:\"hi\",new:[\"boo\",false,true]}",
+                    fleece2JSON(root.encode()));
+        }
+        finally {
+            if (data != null) data.free();
+        }
     }
 
     @Test
     public void testMRoot2() throws LiteCoreException {
         Map<String, Object> map = new HashMap<>();
         map.put("greeting", "hi");
+
         AllocSlice data = encode(map);
+        try {
+            MRoot root = new MRoot(data);
+            assertFalse(root.isMutated());
+            Object obj = root.asNative();
+            assertNotNull(obj);
+            assertTrue(obj instanceof Map);
+            Map<String, Object> dict = (Map<String, Object>) obj;
+            assertEquals("hi", dict.get("greeting"));
+            assertEquals("{greeting:\"hi\"}", fleece2JSON(root.encode()));
+            assertEquals("{greeting:\"hi\"}", fleece2JSON(encode(root)));
 
-        MRoot root = new MRoot(data);
-        assertFalse(root.isMutated());
-        Object obj = root.asNative();
-        assertNotNull(obj);
-        assertTrue(obj instanceof Map);
-        Map<String, Object> dict = (Map<String, Object>) obj;
-        assertEquals("hi", dict.get("greeting"));
-        assertEquals("{greeting:\"hi\"}", fleece2JSON(root.encode()));
-        assertEquals("{greeting:\"hi\"}", fleece2JSON(encode(root)));
-
-        dict.put("hello", "world");
-        assertEquals("hi", dict.get("greeting"));
-        assertEquals("world", dict.get("hello"));
-        assertEquals("{greeting:\"hi\",hello:\"world\"}", fleece2JSON(encode(dict)));
-        assertEquals("{greeting:\"hi\",hello:\"world\"}", fleece2JSON(encode(root.asNative())));
-        assertEquals("{greeting:\"hi\",hello:\"world\"}", fleece2JSON(root.encode()));
-        assertEquals("{greeting:\"hi\",hello:\"world\"}", fleece2JSON(encode(root)));
+            dict.put("hello", "world");
+            assertEquals("hi", dict.get("greeting"));
+            assertEquals("world", dict.get("hello"));
+            assertEquals("{greeting:\"hi\",hello:\"world\"}", fleece2JSON(encode(dict)));
+            assertEquals("{greeting:\"hi\",hello:\"world\"}", fleece2JSON(encode(root.asNative())));
+            assertEquals("{greeting:\"hi\",hello:\"world\"}", fleece2JSON(root.encode()));
+            assertEquals("{greeting:\"hi\",hello:\"world\"}", fleece2JSON(encode(root)));
+        }
+        finally {
+            if (data != null) data.free();
+        }
     }
 }

--- a/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4QueryBaseTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4QueryBaseTest.java
@@ -102,13 +102,16 @@ public class C4QueryBaseTest extends C4BaseTest {
         C4QueryOptions opts = new C4QueryOptions();
         AllocSlice encodedParams = encodeParameters(params);
         C4QueryEnumerator e = query.run(opts, encodedParams);
-        assertNotNull(e);
-        while (e.next()) {
-            docIDs.add(e.getColumns().getValueAt(0).asString());
+        try {
+            assertNotNull(e);
+            while (e.next()) {
+                docIDs.add(e.getColumns().getValueAt(0).asString());
+            }
+            return docIDs;
+        } finally {
+            if (e != null) e.free();
+            if (encodedParams != null) encodedParams.free();
         }
-        if (e != null) e.free();
-        if (encodedParams != null) encodedParams.free();
-        return docIDs;
     }
 
     protected List<List<List<Long>>> runFTS() throws LiteCoreException {
@@ -119,7 +122,7 @@ public class C4QueryBaseTest extends C4BaseTest {
         List<List<List<Long>>> matches = new ArrayList<>();
         C4QueryOptions opts = new C4QueryOptions();
         AllocSlice encodedParams = encodeParameters(params);
-        C4QueryEnumerator e = query.run(opts,encodedParams);
+        C4QueryEnumerator e = query.run(opts, encodedParams);
         assertNotNull(e);
         while (e.next()) {
             List<List<Long>> match = new ArrayList<>();

--- a/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4QueryTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/internal/core/C4QueryTest.java
@@ -612,24 +612,4 @@ public class C4QueryTest extends C4QueryBaseTest {
         e.free();
 
     }
-
-    // - Delete index
-    @Test
-    public void testDeleteIndex() {
-        // TODO
-    }
-
-    // - COLLATION:
-
-    // - DB Query collated
-    @Test
-    public void testDBQueryCollated() {
-        // TODO
-    }
-
-    // - DB Query aggregate collated
-    @Test
-    public void testDBQueryAggregateCollated() {
-        // TODO
-    }
 }

--- a/lib/src/androidTest/java/com/couchbase/lite/internal/fleece/FleeceArray.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/internal/fleece/FleeceArray.java
@@ -170,7 +170,7 @@ public class FleeceArray implements List<Object>, Encodable {
 
     // Implementation of FLEncodable
     @Override
-    public void encodeTo(Encoder enc) {
+    public void encodeTo(FLEncoder enc) {
         _array.encodeTo(enc);
     }
 

--- a/lib/src/androidTest/java/com/couchbase/lite/internal/fleece/FleeceDict.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/internal/fleece/FleeceDict.java
@@ -17,6 +17,7 @@
 //
 package com.couchbase.lite.internal.fleece;
 
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -105,15 +106,22 @@ public class FleeceDict implements Map<String, Object>, Encodable {
     }
 
     @Override
-    public Set<Entry<String, Object>> entrySet() { throw new UnsupportedOperationException(); }
+    public Set<Entry<String, Object>> entrySet() {
+        Set<Entry<String, Object>> entrySet = new HashSet<>();
+        for (String key : dict.getKeys()) {
+            entrySet.add(new AbstractMap.SimpleEntry<String, Object>(key, get(key)));
+        }
+        return entrySet;
+    }
 
-    // Implementation of FLEncodable
+    // FLEncodable
+
     @Override
-    public void encodeTo(Encoder enc) {
+    public void encodeTo(FLEncoder enc) {
         dict.encodeTo(enc);
     }
 
-    // For MValue
+    // MValue
 
     MCollection toMCollection() {
         return dict;

--- a/lib/src/androidTest/java/com/couchbase/lite/internal/fleece/MValueDelegate.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/internal/fleece/MValueDelegate.java
@@ -45,8 +45,8 @@ public class MValueDelegate implements MValue.Delegate {
     }
 
     @Override
-    public void encodeNative(Encoder enc, Object object) {
+    public void encodeNative(FLEncoder enc, Object object) {
         if (object == null) { enc.writeNull(); }
-        else { enc.writeObject(object); }
+        else { enc.writeValue(object); }
     }
 }


### PR DESCRIPTION
1. Used only public API except for RefCounted
    1. Use FLSlice instead of slice.
    2. Use FLSliceResult instead of AllocSlice.
    3. Use FLEncoder instead of Encoder and fix some bugs in FLEncoder.
2. Instead of freeing FLSliceResult in finalize(), make sure the consumer codes call free() method. This will match the way FLSliceResult is used natively.
3. Instead of freeing FLEncoder in finalize(), make sure the customer codes call free() method. This will match the way FLSliceResult is used natively.
4. Ensured to reset the shared FLEncoder after using it.
5. Fixed bug in jstringSlice C++ class when the string is null. This seems to cause a lot of memory issue (bad_alloc) when changing to use FLSlice instead of slice.