### PR TITLE
Add unit tests for Document.getRevisionID() API (CBL-150)

### DIFF
--- a/lib/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/DatabaseTest.java
@@ -1292,7 +1292,7 @@ public class DatabaseTest extends BaseTest {
         Document doc = db.getDocument("abc");
         assertNotNull(doc);
         // NOTE doc1 -> theirs, doc2 -> mine
-        if (doc2.getRevID().compareTo(doc1.getRevID()) > 0)
+        if (doc2.getRevisionID().compareTo(doc1.getRevisionID()) > 0)
         // mine -> doc 2 win
         { assertEquals("newVar", doc.getString("someKey")); }
         else

--- a/lib/src/androidTest/java/com/couchbase/lite/DocumentTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/DocumentTest.java
@@ -40,6 +40,7 @@ import com.couchbase.lite.internal.utils.DateUtils;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -2636,5 +2637,32 @@ public class DocumentTest extends BaseTest {
         Assert.assertNotEquals(mDoc3.hashCode(), doc2.toMutable().hashCode());
         Assert.assertNotEquals(mDoc3.hashCode(), mDoc1.hashCode());
         Assert.assertNotEquals(mDoc3.hashCode(), mDoc2.hashCode());
+    }
+
+    @Test
+    public void testRevisionIDNewDoc() throws CouchbaseLiteException {
+        MutableDocument doc = new MutableDocument();
+        assertNull(doc.getRevisionID());
+        db.save(doc);
+        assertNotNull(doc.getRevisionID());
+    }
+
+    @Test
+    public void testRevisionIDExistingDoc() throws CouchbaseLiteException {
+        MutableDocument mdoc = new MutableDocument("doc1");
+        db.save(mdoc);
+
+        Document doc = db.getDocument("doc1");
+        String docRevID = mdoc.getRevisionID();
+        assertEquals(mdoc.getRevisionID(), docRevID);
+
+        mdoc = doc.toMutable();
+        assertEquals(docRevID, mdoc.getRevisionID());
+
+        mdoc.setInt("int", 88);
+        db.save(mdoc);
+
+        assertEquals(docRevID, doc.getRevisionID());
+        assertNotEquals(docRevID, mdoc.getRevisionID());
     }
 }

--- a/lib/src/androidTest/java/com/couchbase/lite/SaveConflictResolutionTest.kt
+++ b/lib/src/androidTest/java/com/couchbase/lite/SaveConflictResolutionTest.kt
@@ -130,7 +130,7 @@ class SaveConflictResolutionTests : BaseTest() {
         assertEquals(curDoc, doc1a)
 
         // make sure no update to revision and generation
-        assertEquals(doc1a.revID, curDoc.revID)
+        assertEquals(doc1a.revisionID, curDoc.revisionID)
         assertEquals(2, curDoc.generation())
 
         val doc1c = db.getDocument(docID).toMutable()
@@ -157,7 +157,7 @@ class SaveConflictResolutionTests : BaseTest() {
         // make sure no update to revision and generation
         val newDoc = db.getDocument(docID)
         assertEquals(newDoc, doc1c)
-        assertEquals(doc1c.revID, newDoc.revID)
+        assertEquals(doc1c.revisionID, newDoc.revisionID)
         assertEquals(3, newDoc.generation())
     }
 


### PR DESCRIPTION
Added unit tests for the Document.getRevisionID() API.