### PR TITLE
Two commits

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -180,7 +180,7 @@ dependencies {
     compileOnly 'com.google.code.findbugs:annotations:3.0.1'
 
     //noinspection GradleDependency
-    implementation 'com.squareup.okhttp3:okhttp:3.9.1'
+    implementation 'com.squareup.okhttp3:okhttp:3.14.4'
 
     testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$KOTLIN_VERSION"
     testImplementation 'junit:junit:4.12'

--- a/lib/src/main/java/com/couchbase/lite/internal/AndroidExecutionService.java
+++ b/lib/src/main/java/com/couchbase/lite/internal/AndroidExecutionService.java
@@ -25,6 +25,8 @@ import android.support.annotation.NonNull;
 import java.util.concurrent.Executor;
 import java.util.concurrent.RejectedExecutionException;
 
+import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.internal.support.Log;
 import com.couchbase.lite.internal.utils.Preconditions;
 
 
@@ -82,7 +84,10 @@ public final class AndroidExecutionService extends AbstractExecutionService {
         Preconditions.checkArgNotNull(task, "task");
         final Runnable delayedTask = () -> {
             try { executor.execute(task); }
-            catch (RejectedExecutionException ignored) { }
+            catch (RejectedExecutionException e) {
+                // This may happen if the executor was shut down during the delay
+                Log.w(LogDomain.DATABASE, "Rejected execution after delay: " + executor, e);
+            }
         };
         mainHandler.postDelayed(delayedTask, delayMs);
         return new CancellableTask(mainHandler, delayedTask);

--- a/lib/src/main/java/com/couchbase/lite/internal/AndroidExecutionService.java
+++ b/lib/src/main/java/com/couchbase/lite/internal/AndroidExecutionService.java
@@ -84,9 +84,11 @@ public final class AndroidExecutionService extends AbstractExecutionService {
         Preconditions.checkArgNotNull(task, "task");
         final Runnable delayedTask = () -> {
             try { executor.execute(task); }
+            catch (CloseableExecutor.ExecutorClosedExeception e) {
+                Log.w(LogDomain.DATABASE, "Scheduled on closed executor: " + task + ", " + executor);
+            }
             catch (RejectedExecutionException e) {
-                // This may happen if the executor was shut down during the delay
-                Log.w(LogDomain.DATABASE, "Rejected execution after delay: " + executor, e);
+                throw new IllegalStateException("Execution rejected in status change: notification: " + executor, e);
             }
         };
         mainHandler.postDelayed(delayedTask, delayMs);


### PR DESCRIPTION
- CBL-359: Update OkHttp to 3.14.4
- CBL-478: Abort on RejectedExecution exceptions that are not caused by a closed Executor