### PR TITLE
Fix javadoc and sources jar file name

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -389,14 +389,14 @@ def pomConfig = {
 
 // Generate javadoc.jar
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    baseName = project.name
+    baseName = "${CBL_ARTIFACT_ID}"
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
 
 // Generate source.jar
 task sourcesJar(type: Jar) {
-    baseName = project.name
+    baseName = "${CBL_ARTIFACT_ID}"
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
 }


### PR DESCRIPTION
Used artifact id as its based name.

#CBD-3038