### PR TITLE
CBL-164: Move CouchbaseLite.getExecutionService() out of the public API

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -21,6 +21,7 @@ import java.time.Instant
 // ----------------------------------------------------------------
 // Constants
 // ----------------------------------------------------------------
+
 ext {
     CBL_ORG = 'couchbase'
     CBL_GROUP = 'com.couchbase.lite'
@@ -60,9 +61,11 @@ def MAVEN_URL = (!project.hasProperty("mavenUrl")) ? null : mavenUrl
 Properties properties = new Properties()
 properties.load(project.rootProject.file('local.properties').newDataInputStream())
 
+
 // ----------------------------------------------------------------
 // Build
 // ----------------------------------------------------------------
+
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
@@ -86,6 +89,7 @@ android {
         if (TARGET_ABIS != null) {
             ndk { abiFilters TARGET_ABIS }
         }
+
         externalNativeBuild {
             cmake { targets 'LiteCoreJNI' }
         }
@@ -106,12 +110,15 @@ android {
             buildConfigField "String", "BUILD_TIME", "\"${BUILD_TIME}\""
             buildConfigField "String", "BUILD_COMMIT", "\"${BUILD_COMMIT}\""
             buildConfigField "boolean", "ENTERPRISE", "false"
+            buildConfigField "boolean", "CBL_DEBUG", "true"
 
+            debuggable true
             minifyEnabled false
+            testCoverageEnabled false
 
             externalNativeBuild {
                 cmake {
-                    arguments '-DANDROID_STL=c++_static', "-DANDROID_TOOLCHAIN=clang", '-DANDROID_PLATFORM=android-19'
+                    arguments '-DANDROID_STL=c++_static', "-DANDROID_TOOLCHAIN=clang", '-DANDROID_PLATFORM=android-19', '-DCMAKE_BUILD_TYPE=Debug'
                     cppFlags "-std=c++11 -frtti -fexceptions -fPIC"
                 }
             }
@@ -123,12 +130,15 @@ android {
             buildConfigField "String", "BUILD_TIME", "\"${BUILD_TIME}\""
             buildConfigField "String", "BUILD_COMMIT", "\"${BUILD_COMMIT}\""
             buildConfigField "boolean", "ENTERPRISE", "false"
+            buildConfigField "boolean", "CBL_DEBUG", "false"
 
+            debuggable false
             minifyEnabled false
+            testCoverageEnabled false
 
             externalNativeBuild {
                 cmake {
-                    arguments '-DANDROID_STL=c++_static', "-DANDROID_TOOLCHAIN=clang", '-DANDROID_PLATFORM=android-19', '-DCMAKE_BUILD_TYPE=MinSizeRel'
+                    arguments '-DANDROID_STL=c++_static', "-DANDROID_TOOLCHAIN=clang", '-DANDROID_PLATFORM=android-19', '-DCMAKE_BUILD_TYPE=RelWithDebInfo'
                     cppFlags "-std=c++11 -frtti -fexceptions -fPIC"
                 }
             }
@@ -238,19 +248,27 @@ def fileFilter = ['**/R.class', '**/R$*.class', '**/BuildConfig.*', '**/Manifest
 
 /////// Checkstyle
 apply plugin: 'checkstyle'
-task checkstyle(type: Checkstyle) {
+checkstyle {
     description 'Checkstyle'
     group 'verification'
 
+    toolVersion = "8.18"
+
     configFile file("${ETC_DIR}/checkstyle/checkstyle.xml")
     configProperties = ['configDir': file("${ETC_DIR}/checkstyle")]
+
+    showViolations true
+}
+
+task checkstyle(type: Checkstyle) {
+    description 'Checkstyle'
+    group 'verification'
 
     source android.sourceSets.main.java.srcDirs
     include '**/*.java'
     exclude fileFilter
 
     classpath = files()
-    showViolations true
 
     reports {
         xml {
@@ -492,8 +510,9 @@ project.afterEvaluate {
 }
 
 // Clean
-// delete .externalNativeBuild to force rerun of cmake.  This is necessary because 'clean'
-// deletes the file 'zconf.h' which is in .../build/intermediates, causing subsequent builds to fail.
+// delete .externalNativeBuild and .cxx directories to force rerun of cmake.
+// This is necessary because 'clean' deletes the file 'zconf.h' which is in
+// .../build/intermediates, causing subsequent builds to fail.
 clean.doLast {
     delete "${MODULE_DIR}/.externalNativeBuild"
     delete "${MODULE_DIR}/.cxx"
@@ -501,8 +520,11 @@ clean.doLast {
 
 def getLicenseVersion() {
     def version = "master"
-    try { version = 'git rev-parse --short HEAD'.execute([], file("${ROOT_DIR}/product-texts")).text.trim() }
-    catch (Exception ignore) {}
+    try {
+        version = 'git rev-parse --short HEAD'.execute([], file("${ROOT_DIR}/product-texts")).text.trim()
+    }
+    catch (Exception ignore) {
+    }
     return version
 }
 
@@ -510,9 +532,12 @@ def getBuildCommit() {
     def commit = "unknown"
     try {
         commit = 'git rev-parse --short HEAD'.execute([], file(PROJECT_DIR)).text.trim()
-        if ('git status -uno --porcelain'.execute([], file(PROJECT_DIR)).text.length() <= 0) { commit += "+" }
+        if ('git status -uno --porcelain'.execute([], file(PROJECT_DIR)).text.length() <= 0) {
+            commit += "+"
+        }
     }
-    catch (Exception ignore) {}
+    catch (Exception ignore) {
+    }
     return commit
 }
 

--- a/lib/src/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
+++ b/lib/src/androidTest/java/com/couchbase/lite/PlatformBaseTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.ExecutionService;
 import com.couchbase.lite.internal.support.Log;
 
@@ -51,27 +52,27 @@ public abstract class PlatformBaseTest implements PlatformTest {
     }
 
     @Override
-    public String getDatabaseDirectory() { return CouchbaseLite.getDbDirectoryPath(); }
+    public String getDatabaseDirectory() { return CouchbaseLiteInternal.getDbDirectoryPath(); }
 
     @Override
-    public String getTempDirectory(String name) { return CouchbaseLite.getTmpDirectory(name); }
+    public String getTempDirectory(String name) { return CouchbaseLiteInternal.getTmpDirectory(name); }
 
     @Override
     public InputStream getAsset(String asset) {
-        try { return CouchbaseLite.getContext().getAssets().open(asset); }
+        try { return CouchbaseLiteInternal.getContext().getAssets().open(asset); }
         catch (IOException ignore) { }
         return null;
     }
 
     @Override
     public void executeAsync(long delayMs, Runnable task) {
-        ExecutionService executionService = CouchbaseLite.getExecutionService();
+        ExecutionService executionService = CouchbaseLiteInternal.getExecutionService();
         executionService.postDelayedOnExecutor(delayMs, executionService.getMainExecutor(), task);
     }
 
     @Override
     public void reloadStandardErrorMessages() {
-        Log.initLogging(CouchbaseLite.loadErrorMessages(InstrumentationRegistry.getTargetContext()));
+        Log.initLogging(CouchbaseLiteInternal.loadErrorMessages(InstrumentationRegistry.getTargetContext()));
 
     }
 

--- a/lib/src/main/java/com/couchbase/lite/CouchbaseLite.java
+++ b/lib/src/main/java/com/couchbase/lite/CouchbaseLite.java
@@ -18,136 +18,27 @@ package com.couchbase.lite;
 import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
 
 import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.ref.SoftReference;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Scanner;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 
-import org.json.JSONException;
-import org.json.JSONObject;
-
-import com.couchbase.lite.internal.AndroidExecutionService;
-import com.couchbase.lite.internal.ExecutionService;
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.fleece.MValue;
-import com.couchbase.lite.internal.support.Log;
-import com.couchbase.lite.internal.utils.Preconditions;
 
 
 public final class CouchbaseLite {
     // Utility class
     private CouchbaseLite() {}
 
-    private static final String LITECORE_JNI_LIBRARY = "LiteCoreJNI";
-
-    private static final AtomicReference<ExecutionService> EXECUTION_SERVICE = new AtomicReference<>();
-    private static final AtomicReference<SoftReference<Context>> CONTEXT = new AtomicReference<>();
-
-    private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
-
     /**
      * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
      */
-    public static void init(@NonNull Context ctxt) {
-        Preconditions.checkArgNotNull(ctxt, "context");
+    public static void init(@NonNull Context ctxt) { init(new MValueDelegate(), false, null, ctxt); }
 
-        if (INITIALIZED.getAndSet(true)) { return; }
-
-        System.loadLibrary(LITECORE_JNI_LIBRARY);
-
-        MValue.registerDelegate(new MValueDelegate());
-
-        CONTEXT.set(new SoftReference<>(ctxt.getApplicationContext()));
-
-        Log.initLogging(loadErrorMessages(ctxt));
-        com.couchbase.lite.Database.log.getConsole().setLevel(LogLevel.WARNING);
-    }
-
-    /**
-     * This method is not part of the public API.
-     * It will be removed in a future release.
-     */
-    public static ExecutionService getExecutionService() {
-        ExecutionService executionService = EXECUTION_SERVICE.get();
-        if (executionService == null) {
-            EXECUTION_SERVICE.compareAndSet(null, new AndroidExecutionService());
-            executionService = EXECUTION_SERVICE.get();
-        }
-        return executionService;
-    }
-
-    static void requireInit(String message) {
-        if (!INITIALIZED.get()) {
-            throw new IllegalStateException(message + ".  Did you forget to call CouchbaseLite.init()?");
-        }
-    }
-
-    @NonNull
-    static Context getContext() {
-        requireInit("Application context not initialized");
-        final SoftReference<Context> contextRef = CONTEXT.get();
-
-        final Context ctxt = contextRef.get();
-        if (ctxt == null) { throw new IllegalStateException("Context is null"); }
-
-        return ctxt;
-    }
-
-    static String getDbDirectoryPath() {
-        requireInit("Database directory not initialized");
-        return getContext().getFilesDir().getAbsolutePath();
-    }
-
-    static String getTmpDirectory(@NonNull String name) {
-        requireInit("Temp directory not initialized");
-        return verifyDir(getContext().getExternalFilesDir(name));
-    }
-
-    static String getTmpDirectory(String root, String name) {
-        requireInit("Temp directory not initialized");
-        return verifyDir(new File(root, name));
-    }
-
-    @VisibleForTesting
-    static void reset() { INITIALIZED.set(false); }
-
-    @VisibleForTesting
-    @NonNull
-    static Map<String, String> loadErrorMessages(@NonNull Context ctxt) {
-        final Map<String, String> errorMessages = new HashMap<>();
-
-        try (InputStream is = ctxt.getResources().openRawResource(R.raw.errors)) {
-            final JSONObject root = new JSONObject(new Scanner(is, "UTF-8").useDelimiter("\\A").next());
-
-            for (Iterator<String> errors = root.keys(); errors.hasNext();) {
-                final String error = errors.next();
-                errorMessages.put(error, root.getString(error));
-            }
-        }
-        catch (IOException | JSONException e) {
-            Log.e(LogDomain.DATABASE, "Failed to load error messages!", e);
-        }
-
-        return errorMessages;
-    }
-
-    @Nullable
-    private static String verifyDir(@Nullable File dir) {
-        if (dir == null) { return null; }
-
-        IOException err = null;
-        try {
-            if ((dir.exists() && dir.isDirectory()) || dir.mkdirs()) { return dir.getCanonicalPath(); }
-        }
-        catch (IOException e) { err = e; }
-
-        throw new IllegalStateException("Cannot create or access directory at " + dir, err);
+    private static void init(
+        @NonNull MValue.Delegate mValueDelegate,
+        boolean debugging,
+        @Nullable File rootDirectory,
+        @NonNull Context ctxt) {
+        CouchbaseLiteInternal.init(mValueDelegate, debugging, rootDirectory, ctxt);
     }
 }

--- a/lib/src/main/java/com/couchbase/lite/NetworkReachabilityManager.java
+++ b/lib/src/main/java/com/couchbase/lite/NetworkReachabilityManager.java
@@ -24,6 +24,7 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
+import com.couchbase.lite.internal.CouchbaseLiteInternal;
 import com.couchbase.lite.internal.support.Log;
 
 
@@ -51,7 +52,7 @@ final class NetworkReachabilityManager extends AbstractNetworkReachabilityManage
 
     NetworkReachabilityManager() {
         this.receiver = new NetworkReceiver();
-        this.context = CouchbaseLite.getContext();
+        this.context = CouchbaseLiteInternal.getContext();
 
         this.listening = false;
     }

--- a/lib/src/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
+++ b/lib/src/main/java/com/couchbase/lite/internal/CouchbaseLiteInternal.java
@@ -1,0 +1,161 @@
+//
+// Copyright (c) 2019 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+package com.couchbase.lite.internal;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.ref.SoftReference;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Scanner;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import com.couchbase.lite.BuildConfig;
+import com.couchbase.lite.LogDomain;
+import com.couchbase.lite.LogLevel;
+import com.couchbase.lite.R;
+import com.couchbase.lite.internal.fleece.MValue;
+import com.couchbase.lite.internal.support.Log;
+import com.couchbase.lite.internal.utils.Preconditions;
+
+
+public final class CouchbaseLiteInternal {
+    // Utility class
+    private CouchbaseLiteInternal() {}
+
+    private static final String LITECORE_JNI_LIBRARY = "LiteCoreJNI";
+
+    private static final AtomicReference<ExecutionService> EXECUTION_SERVICE = new AtomicReference<>();
+    private static final AtomicReference<SoftReference<Context>> CONTEXT = new AtomicReference<>();
+
+    private static final AtomicBoolean INITIALIZED = new AtomicBoolean(false);
+
+    /**
+     * Initialize CouchbaseLite library. This method MUST be called before using CouchbaseLite.
+     */
+    public static void init(
+        @NonNull MValue.Delegate mValueDelegate,
+        boolean debugging,
+        @Nullable File rootDirectory,
+        @NonNull Context ctxt) {
+        Preconditions.checkArgNotNull(ctxt, "context");
+
+        if (INITIALIZED.getAndSet(true)) { return; }
+
+        System.loadLibrary(LITECORE_JNI_LIBRARY);
+
+        MValue.registerDelegate(mValueDelegate);
+
+        CONTEXT.set(new SoftReference<>(ctxt.getApplicationContext()));
+
+        Log.initLogging(loadErrorMessages(ctxt));
+        com.couchbase.lite.Database.log.getConsole().setLevel(LogLevel.WARNING);
+    }
+
+    public static boolean isDebugging() { return BuildConfig.CBL_DEBUG; }
+
+    /**
+     * This method is not part of the public API.
+     * It will be removed in a future release.
+     */
+    public static ExecutionService getExecutionService() {
+        ExecutionService executionService = EXECUTION_SERVICE.get();
+        if (executionService == null) {
+            EXECUTION_SERVICE.compareAndSet(null, new AndroidExecutionService());
+            executionService = EXECUTION_SERVICE.get();
+        }
+        return executionService;
+    }
+
+    public static void requireInit(String message) {
+        if (!INITIALIZED.get()) {
+            throw new IllegalStateException(message + ".  Did you forget to call CouchbaseLite.init()?");
+        }
+    }
+
+    @NonNull
+    public static Context getContext() {
+        requireInit("Application context not initialized");
+        final SoftReference<Context> contextRef = CONTEXT.get();
+
+        final Context ctxt = contextRef.get();
+        if (ctxt == null) { throw new IllegalStateException("Context is null"); }
+
+        return ctxt;
+    }
+
+    public static String getDbDirectoryPath() {
+        requireInit("Database directory not initialized");
+        return getContext().getFilesDir().getAbsolutePath();
+    }
+
+    public static String getTmpDirectory(@NonNull String name) {
+        requireInit("Temp directory not initialized");
+        return verifyDir(getContext().getExternalFilesDir(name));
+    }
+
+    public static String getTmpDirectory(String root, String name) {
+        requireInit("Temp directory not initialized");
+        return verifyDir(new File(root, name));
+    }
+
+    @VisibleForTesting
+    public static void reset() { INITIALIZED.set(false); }
+
+    @VisibleForTesting
+    @NonNull
+    public static Map<String, String> loadErrorMessages(@NonNull Context ctxt) {
+        final Map<String, String> errorMessages = new HashMap<>();
+
+        try (InputStream is = ctxt.getResources().openRawResource(R.raw.errors)) {
+            final JSONObject root = new JSONObject(new Scanner(is, "UTF-8").useDelimiter("\\A").next());
+
+            for (Iterator<String> errors = root.keys(); errors.hasNext();) {
+                final String error = errors.next();
+                errorMessages.put(error, root.getString(error));
+            }
+        }
+        catch (IOException | JSONException e) {
+            Log.e(LogDomain.DATABASE, "Failed to load error messages!", e);
+        }
+
+        return errorMessages;
+    }
+
+    @Nullable
+    private static String verifyDir(@Nullable File dir) {
+        if (dir == null) { return null; }
+
+        IOException err = null;
+        try {
+            if ((dir.exists() && dir.isDirectory()) || dir.mkdirs()) { return dir.getCanonicalPath(); }
+        }
+        catch (IOException e) { err = e; }
+
+        throw new IllegalStateException("Cannot create or access directory at " + dir, err);
+    }
+}


### PR DESCRIPTION
Move most of CouchbaseLite to CouchbaseLiteInternal hiding CouchbaseLite.getExecutionService()

This is a coordinated update with CBL-java.  There are four changes:
1) move most functionality from CouchbaseLite to CouchbaseLiteInternal
2) rename references to  CouchbaseLite to CouchbaseLiteInternal
3) Add a debug flag in CBLInternal
4) sync build.gradle with CBL-android-ee for easy comparison